### PR TITLE
Approximate Block Count

### DIFF
--- a/app/block/syncer.go
+++ b/app/block/syncer.go
@@ -69,7 +69,7 @@ func SyncMissingBlocksInDB(client *ethclient.Client, _db *gorm.DB, redisClient *
 
 	for {
 		currentBlockNumber := db.GetCurrentBlockNumber(_db)
-		blockCount := db.GetBlockCount(_db)
+		blockCount := db.GetApproximateBlockCount(_db)
 		// If all blocks present in between 0 to latest block in network
 		// `ette` sleeps for 1 minute & again get to work
 		if currentBlockNumber+1 == blockCount {

--- a/app/db/query.go
+++ b/app/db/query.go
@@ -51,7 +51,7 @@ func GetBlockCount(db *gorm.DB) uint64 {
 func GetApproximateBlockCount(db *gorm.DB) uint64 {
 	var number int64
 
-	if err := db.Raw("select reltuples::bigint from pg_class where relname = 'blocks'").Scan(&number); err != nil {
+	if err := db.Raw("select reltuples::bigint from pg_class where relname = 'blocks'").Scan(&number).Error; err != nil {
 		return 0
 	}
 

--- a/app/db/query.go
+++ b/app/db/query.go
@@ -41,6 +41,23 @@ func GetBlockCount(db *gorm.DB) uint64 {
 	return uint64(number)
 }
 
+// GetApproximateBlockCount - Due to performance issue faced while executing
+// `select count(*) from blocks;`, using approximate row count in table,
+// which might not be always correct because it's cached value & get
+// updated very frequently, due to multi threaded nature of database engine.
+//
+// But for serving queries we don't want user to wait for very long time,
+// so we're using it, instead of `select count(*) from blocks;`
+func GetApproximateBlockCount(db *gorm.DB) uint64 {
+	var number int64
+
+	if err := db.Raw("select reltuples::bigint from pg_class where relname = 'blocks'").Scan(&number); err != nil {
+		return 0
+	}
+
+	return uint64(number)
+}
+
 // GetBlockByHash - Given blockhash finds out block related information
 //
 // If not found, returns nil

--- a/app/rest/rest.go
+++ b/app/rest/rest.go
@@ -473,7 +473,7 @@ func RunHTTPServer(_db *gorm.DB, _lock *sync.Mutex, _synced *d.SyncState, _redis
 		grp.GET("/synced", func(c *gin.Context) {
 
 			currentBlockNumber := db.GetCurrentBlockNumber(_db)
-			blockCountInDB := db.GetBlockCount(_db)
+			blockCountInDB := db.GetApproximateBlockCount(_db)
 			remaining := (currentBlockNumber + 1) - blockCountInDB
 
 			_lock.Lock()


### PR DESCRIPTION
Using approximate block count instead of `select count(*) from blocks;` for avoiding full table scan. May not always return correct result, but execution is super fast.