### PR TITLE
Accurate block count from in-memory program state

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -49,7 +49,7 @@ func bootstrap(configFile, subscriptionPlansFile string) (*d.BlockChainNodeConne
 	graph.GetDatabaseConnection(_db)
 
 	_lock := &sync.Mutex{}
-	_synced := &d.SyncState{Done: 0}
+	_synced := &d.SyncState{Done: 0, StartedWith: db.GetBlockCount(_db)}
 
 	return _connection, _redisClient, _db, _lock, _synced
 }

--- a/app/block/syncer.go
+++ b/app/block/syncer.go
@@ -69,7 +69,11 @@ func SyncMissingBlocksInDB(client *ethclient.Client, _db *gorm.DB, redisClient *
 
 	for {
 		currentBlockNumber := db.GetCurrentBlockNumber(_db)
-		blockCount := db.GetApproximateBlockCount(_db)
+
+		_lock.Lock()
+		blockCount := _synced.StartedWith + _synced.Done
+		_lock.Unlock()
+
 		// If all blocks present in between 0 to latest block in network
 		// `ette` sleeps for 1 minute & again get to work
 		if currentBlockNumber+1 == blockCount {

--- a/app/data/data.go
+++ b/app/data/data.go
@@ -23,8 +23,9 @@ type BlockChainNodeConnection struct {
 
 // SyncState - Whether `ette` is synced with blockchain or not
 type SyncState struct {
-	Done      uint64
-	StartedAt time.Time
+	Done        uint64
+	StartedWith uint64
+	StartedAt   time.Time
 }
 
 // Block - Block related info to be delivered to client in this format

--- a/app/rest/rest.go
+++ b/app/rest/rest.go
@@ -473,12 +473,12 @@ func RunHTTPServer(_db *gorm.DB, _lock *sync.Mutex, _synced *d.SyncState, _redis
 		grp.GET("/synced", func(c *gin.Context) {
 
 			currentBlockNumber := db.GetCurrentBlockNumber(_db)
-			blockCountInDB := db.GetApproximateBlockCount(_db)
-			remaining := (currentBlockNumber + 1) - blockCountInDB
 
 			_lock.Lock()
 			defer _lock.Unlock()
 
+			blockCountInDB := _synced.StartedWith + _synced.Done
+			remaining := (currentBlockNumber + 1) - blockCountInDB
 			elapsed := time.Now().UTC().Sub(_synced.StartedAt)
 
 			c.JSON(http.StatusOK, gin.H{


### PR DESCRIPTION
Calculating current accurate block count from in-memory program state holder, not bound to high IO delay anymore