### PR TITLE
Fresh block count fetcher

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -49,7 +49,7 @@ func bootstrap(configFile, subscriptionPlansFile string) (*d.BlockChainNodeConne
 	graph.GetDatabaseConnection(_db)
 
 	_lock := &sync.Mutex{}
-	_synced := &d.SyncState{Done: 0, StartedWith: db.GetBlockCount(_db)}
+	_synced := &d.SyncState{Done: 0, BlockCountInDB: db.GetBlockCount(_db)}
 
 	return _connection, _redisClient, _db, _lock, _synced
 }

--- a/app/block/block.go
+++ b/app/block/block.go
@@ -17,6 +17,22 @@ import (
 	"gorm.io/gorm"
 )
 
+// Running a different executor for keeping block count in memory, as fresh as we can keep
+func keepBlockCountInMemory(_db *gorm.DB, _lock *sync.Mutex, _synced *d.SyncState) {
+
+	for {
+		count := db.GetBlockCount(_db)
+		if count == 0 {
+			continue
+		}
+
+		_lock.Lock()
+		_synced.BlockCountInDB = count
+		_lock.Unlock()
+	}
+
+}
+
 // Fetching block content using blockHash
 func fetchBlockByHash(client *ethclient.Client, hash common.Hash, number string, _db *gorm.DB, redisClient *redis.Client, redisKey string, _lock *sync.Mutex, _synced *d.SyncState) {
 	block, err := client.BlockByHash(context.Background(), hash)

--- a/app/block/block.go
+++ b/app/block/block.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math/big"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -21,6 +22,7 @@ import (
 func keepBlockCountInMemory(_db *gorm.DB, _lock *sync.Mutex, _synced *d.SyncState) {
 
 	for {
+		time.Sleep(time.Duration(100) * time.Millisecond)
 		count := db.GetBlockCount(_db)
 		if count == 0 {
 			continue
@@ -29,6 +31,7 @@ func keepBlockCountInMemory(_db *gorm.DB, _lock *sync.Mutex, _synced *d.SyncStat
 		_lock.Lock()
 		_synced.BlockCountInDB = count
 		_lock.Unlock()
+		log.Printf("[+] Obtained fresh block count in DB")
 	}
 
 }

--- a/app/block/listener.go
+++ b/app/block/listener.go
@@ -42,6 +42,9 @@ func SubscribeToNewBlocks(connection *d.BlockChainNodeConnection, _db *gorm.DB, 
 	//
 	// Uses Redis backed queue for fetching pending block hash & retries
 	go retryBlockFetching(connection.RPC, _db, redisClient, redisKey, _lock, _synced)
+	// Keeping, as fresh as possible, block count in memory, which will be helpful
+	// in answersing queries faster
+	go keepBlockCountInMemory(_db, _lock, _synced)
 	// Last time `ette` stopped syncing here
 	currentHighestBlockNumber := db.GetCurrentBlockNumber(_db)
 

--- a/app/block/syncer.go
+++ b/app/block/syncer.go
@@ -106,10 +106,12 @@ func SyncMissingBlocksInDB(client *ethclient.Client, _db *gorm.DB, redisClient *
 
 	for {
 		log.Printf("[*] Starting missing block finder")
+
 		currentBlockNumber := db.GetCurrentBlockNumber(_db)
 
+		// Safely reading shared variable
 		_lock.Lock()
-		blockCount := _synced.StartedWith + _synced.Done
+		blockCount := _synced.BlockCountInDB
 		_lock.Unlock()
 
 		// If all blocks present in between 0 to latest block in network

--- a/app/data/data.go
+++ b/app/data/data.go
@@ -37,9 +37,9 @@ type BlockChainNodeConnection struct {
 
 // SyncState - Whether `ette` is synced with blockchain or not
 type SyncState struct {
-	Done        uint64
-	StartedWith uint64
-	StartedAt   time.Time
+	Done           uint64
+	StartedAt      time.Time
+	BlockCountInDB uint64
 }
 
 // Block - Block related info to be delivered to client in this format

--- a/app/rest/rest.go
+++ b/app/rest/rest.go
@@ -477,13 +477,13 @@ func RunHTTPServer(_db *gorm.DB, _lock *sync.Mutex, _synced *d.SyncState, _redis
 			_lock.Lock()
 			defer _lock.Unlock()
 
-			blockCountInDB := _synced.StartedWith + _synced.Done
+			blockCountInDB := _synced.BlockCountInDB
 			remaining := (currentBlockNumber + 1) - blockCountInDB
 			elapsed := time.Now().UTC().Sub(_synced.StartedAt)
 
-			eta := "0s"
 			status := fmt.Sprintf("%.2f %%", (float64(blockCountInDB)/float64(currentBlockNumber+1))*100)
-			if !(status == "100.00 %") {
+			eta := "0s"
+			if blockCountInDB < currentBlockNumber+1 {
 				eta = (time.Duration((elapsed.Seconds()/float64(_synced.Done))*float64(remaining)) * time.Second).String()
 			}
 


### PR DESCRIPTION
Running fresh block count fetcher in a diiferent thread of execution, so that querying party does not need to wait for long