### PR TITLE
Develop

### DIFF
--- a/app/block/syncer.go
+++ b/app/block/syncer.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"fmt"
 	"log"
 	"runtime"
 	"sync"
@@ -131,7 +132,7 @@ func SyncMissingBlocksInDB(client *ethclient.Client, _db *gorm.DB, redisClient *
 
 				// Worker fetches block by number from local storage
 				block := db.GetBlock(j.DB, j.Block)
-				if block == nil {
+				if block == nil && !checkExistenceOfBlockNumberInRedisQueue(redisClient, redisKey, fmt.Sprintf("%d", j.Block)) {
 					// If not found, block fetching cycle is run, for this block
 					fetchBlockByNumber(j.Client, j.Block, j.DB, j.RedisClient, j.RedisKey, j.Lock, j.Synced)
 				}

--- a/app/db/subscription.go
+++ b/app/db/subscription.go
@@ -33,6 +33,11 @@ func AddNewSubscriptionPlan(_db *gorm.DB, name string, deliveryCount uint64) {
 // content of its, which will be persisted into database, into `subscription_plans` table
 func PersistAllSubscriptionPlans(_db *gorm.DB, file string) {
 
+	if DoesSubscriptionPlanTableExist(_db) {
+		log.Printf("[+] Subscription plans already persisted, not touching\n")
+		return
+	}
+
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
 		log.Fatalf("[!] Failed to read content from subscription plan file : %s\n", err.Error())

--- a/app/db/subscription.go
+++ b/app/db/subscription.go
@@ -57,21 +57,19 @@ func AddNewSubscriptionPlan(_db *gorm.DB, name string, deliveryCount uint64) {
 		return
 	}
 
-	// No change made in `.plans.json` file
-	// i.e. subscription plan is already persisted
-	if count == deliveryCount {
-		return
-	}
-
-	// Entry doesn't yet exist, attempting to create it
-	if count == 0 {
+	switch count {
+	case 0:
+		// Entry doesn't yet exist, attempting to create it
 		CreateSubscriptionPlan(_db, name, deliveryCount)
+	case deliveryCount:
+		// No change made in `.plans.json` file
+		// i.e. subscription plan is already persisted
 		return
+	default:
+		// Plan with same name already persisted in table
+		// trying to update it
+		UpdateSubscriptionPlan(_db, name, deliveryCount)
 	}
-
-	// Plan with same name already persisted in table
-	// trying to update it
-	UpdateSubscriptionPlan(_db, name, deliveryCount)
 
 }
 

--- a/app/db/subscription.go
+++ b/app/db/subscription.go
@@ -15,6 +15,17 @@ func DoesSubscriptionPlanTableExist(_db *gorm.DB) bool {
 	return _db.Migrator().HasTable(&SubscriptionPlans{})
 }
 
+// DoesSubscriptionPlanExist - Given subscription plan name, checks whether it exists or not
+func DoesSubscriptionPlanExist(_db *gorm.DB, planName string) bool {
+	var subscriptionPlan SubscriptionPlans
+
+	if err := _db.Where("name = ?", planName).Find(&subscriptionPlan).Error; err != nil {
+		return false
+	}
+
+	return true
+}
+
 // AddNewSubscriptionPlan - Adding new subcription plan to database
 // after those being read from .plans.json
 func AddNewSubscriptionPlan(_db *gorm.DB, name string, deliveryCount uint64) {

--- a/app/db/subscription.go
+++ b/app/db/subscription.go
@@ -9,6 +9,12 @@ import (
 	"gorm.io/gorm"
 )
 
+// DoesSubscriptionPlanTableExist - Checks whether this table is already migrated or not, if yes,
+// no need to do it again
+func DoesSubscriptionPlanTableExist(_db *gorm.DB) bool {
+	return _db.Migrator().HasTable(&SubscriptionPlans{})
+}
+
 // AddNewSubscriptionPlan - Adding new subcription plan to database
 // after those being read from .plans.json
 func AddNewSubscriptionPlan(_db *gorm.DB, name string, deliveryCount uint64) {

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -75,5 +75,6 @@ create table subscription_plans (
 
 create table subscription_details (
     address char(42) primary key,
-    subscriptionplan int not null
+    subscriptionplan int not null,
+    foreign key (subscriptionplan) references subscription_plans(id)
 );


### PR DESCRIPTION
## changes

- Before fetching block in missing block finder, checks whether block is already added in retry queue or not
- If yes, no need to fetch it again
- For subscriptions plan table, checking whether plan is already persisted or not
- If yes, no need to try to persist it again
- Previously it used to show some error(s) in console log