### PR TITLE
Controlled Concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ cd ette
     ```
 
     - For testing historical data query using browser based GraphQL Playground in `ette`, you can set `EtteGraphQLPlayGround` to `yes` in config file
+    - For processing block(s)/ tx(s) concurrently, it'll create `ConcurrencyFactor * #-of CPUs on machine` workers, who will pick up jobs submitted to them.
+    - If nothing is specified, it defaults to 1 & assuming you're running `ette` on machine with 4 CPUs, it'll spawn worker pool of size 4. But more number of jobs can be submitted, only 4 can be running at max.
+    - 👆 being done for controlling concurrency level, by putting more control on user's hand.
 
 ```
 RPCUrl=https://<domain-name>
@@ -113,6 +116,7 @@ Domain=localhost
 Production=yes
 EtteMode=3
 EtteGraphQLPlayGround=yes
+ConcurrencyFactor=2
 ```
 
 - Create another file in same directory, named `.plans.json`, whose content will look like 👇.

--- a/app/app.go
+++ b/app/app.go
@@ -95,6 +95,9 @@ func Run(configFile, subscriptionPlansFile string) {
 			return
 		}
 
+		// Stopping process
+		os.Exit(0)
+
 	}()
 
 	// Pushing block header propagation listener to another thread of execution

--- a/app/app.go
+++ b/app/app.go
@@ -77,7 +77,6 @@ func Run(configFile, subscriptionPlansFile string) {
 	go func() {
 
 		<-interruptChan
-		log.Printf("[+] Gracefully shutting down `ette`")
 
 		sql, err := _db.DB()
 		if err != nil {
@@ -96,6 +95,7 @@ func Run(configFile, subscriptionPlansFile string) {
 		}
 
 		// Stopping process
+		log.Printf(color.Magenta.Sprintf("\n[+] Gracefully shut down `ette`"))
 		os.Exit(0)
 
 	}()

--- a/app/app.go
+++ b/app/app.go
@@ -57,9 +57,13 @@ func bootstrap(configFile, subscriptionPlansFile string) (*d.BlockChainNodeConne
 // Run - Application to be invoked from main runner using this function
 func Run(configFile, subscriptionPlansFile string) {
 	_connection, _redisClient, _db, _lock, _synced := bootstrap(configFile, subscriptionPlansFile)
+	_redisInfo := d.RedisInfo{
+		Client:    _redisClient,
+		QueueName: "blocks",
+	}
 
 	// Pushing block header propagation listener to another thread of execution
-	go blk.SubscribeToNewBlocks(_connection, _db, _lock, _synced, _redisClient, "blocks")
+	go blk.SubscribeToNewBlocks(_connection, _db, _lock, _synced, &_redisInfo)
 
 	// Starting http server on main thread
 	rest.RunHTTPServer(_db, _lock, _synced, _redisClient)

--- a/app/app.go
+++ b/app/app.go
@@ -3,6 +3,8 @@ package app
 import (
 	"context"
 	"log"
+	"os"
+	"os/signal"
 	"sync"
 
 	"github.com/go-redis/redis/v8"
@@ -65,9 +67,17 @@ func Run(configFile, subscriptionPlansFile string) {
 		QueueName: "blocks",
 	}
 
-	// All storage resources being used gets cleaned up
+	// Attempting to listen to Ctrl+C signal
+	// and when received gracefully shutting down `ette`
+	interruptChan := make(chan os.Signal, 1)
+	signal.Notify(interruptChan, os.Interrupt)
+
+	// All resources being used gets cleaned up
 	// when we're returning from this function scope
-	defer func() {
+	go func() {
+
+		<-interruptChan
+		log.Printf("[+] Gracefully shutting down `ette`")
 
 		sql, err := _db.DB()
 		if err != nil {

--- a/app/block/block.go
+++ b/app/block/block.go
@@ -119,7 +119,7 @@ func fetchBlockContent(client *ethclient.Client, block *types.Block, _db *gorm.D
 	// -- Tx processing starting
 	// Creating job processor queue
 	// which will process all tx(s), concurrently
-	wp := workerpool.New(runtime.NumCPU())
+	wp := workerpool.New(runtime.NumCPU() * int(cfg.GetConcurrencyFactor()))
 
 	// Concurrently trying to process all tx(s) for this block, in hope of better performance
 	for _, v := range block.Transactions() {

--- a/app/block/block.go
+++ b/app/block/block.go
@@ -130,7 +130,7 @@ func fetchBlockContent(client *ethclient.Client, block *types.Block, _db *gorm.D
 		func(tx *types.Transaction) {
 			wp.Submit(func() {
 
-				fetchTransactionByHash(client,
+				FetchTransactionByHash(client,
 					block,
 					tx,
 					_db,

--- a/app/block/block.go
+++ b/app/block/block.go
@@ -116,6 +116,7 @@ func fetchBlockContent(client *ethclient.Client, block *types.Block, _db *gorm.D
 	// which are trying to fetch all tx(s) present in block, concurrently
 	returnValChan := make(chan bool)
 
+	// -- Tx processing starting
 	// Creating job processor queue
 	// which will process all tx(s), concurrently
 	wp := workerpool.New(runtime.NumCPU())
@@ -163,6 +164,7 @@ func fetchBlockContent(client *ethclient.Client, block *types.Block, _db *gorm.D
 	// Otherwise control flow will not be able to come here
 	// it'll keep looping in 👆 loop, reading from channel
 	wp.Stop()
+	// -- Tx processing ending
 
 	// When all tx(s) are successfully processed ( as they have informed us over go channel ),
 	// we're happy to exit from this context, given that none of them failed

--- a/app/block/block.go
+++ b/app/block/block.go
@@ -129,7 +129,6 @@ func fetchBlockContent(client *ethclient.Client, block *types.Block, _db *gorm.D
 		//
 		// Which is being read 👇
 		func(tx *types.Transaction) {
-
 			wp.Submit(func() {
 
 				fetchTransactionByHash(client, block, tx, _db,
@@ -137,7 +136,6 @@ func fetchBlockContent(client *ethclient.Client, block *types.Block, _db *gorm.D
 					_lock, _synced, returnValChan)
 
 			})
-
 		}(v)
 
 	}

--- a/app/block/fetch.go
+++ b/app/block/fetch.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/gookit/color"
-	cfg "github.com/itzmeanjan/ette/app/config"
 	d "github.com/itzmeanjan/ette/app/data"
 	"github.com/itzmeanjan/ette/app/db"
 	"gorm.io/gorm"
@@ -70,20 +69,6 @@ func FetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *ty
 		// from blockchain node
 		returnValChan <- nil
 		return
-	}
-
-	// Checking whether `ette` is running in real-time data delivery
-	// mode or not
-	//
-	// If yes & this tx, event log data can be published,
-	// we'll try to publish data to redis pubsub channel
-	// which will be eventually broadcasted to all clients subscribed to
-	// topic of their interest
-	if publishable && (cfg.Get("EtteMode") == "2" || cfg.Get("EtteMode") == "3") {
-
-		PublishTx(block.NumberU64(), tx, sender, receipt, redis)
-		PublishEvents(block.NumberU64(), receipt, redis)
-
 	}
 
 	// Passing all tx related data to listener go routine

--- a/app/block/listener.go
+++ b/app/block/listener.go
@@ -95,7 +95,7 @@ func SubscribeToNewBlocks(connection *d.BlockChainNodeConnection, _db *gorm.DB, 
 
 				wp.Submit(func() {
 
-					fetchBlockByHash(connection.RPC,
+					FetchBlockByHash(connection.RPC,
 						blockHash,
 						blockNumber,
 						_db,

--- a/app/block/listener.go
+++ b/app/block/listener.go
@@ -81,8 +81,8 @@ func SubscribeToNewBlocks(connection *d.BlockChainNodeConnection, _db *gorm.DB, 
 
 					// Making sure on when next latest block header is received, it'll not
 					// start another syncer
-					first = false
 				}
+				first = false
 
 			}
 

--- a/app/block/listener.go
+++ b/app/block/listener.go
@@ -40,7 +40,7 @@ func SubscribeToNewBlocks(connection *d.BlockChainNodeConnection, _db *gorm.DB, 
 	first := true
 	// Creating a job queue of size `#-of CPUs present in machine`
 	// where block fetching requests to be submitted
-	wp := workerpool.New(runtime.NumCPU())
+	wp := workerpool.New(runtime.NumCPU() * int(cfg.GetConcurrencyFactor()))
 	// Scheduling worker pool closing, to be called,
 	// when returning from this execution scope i.e. function
 	defer wp.Stop()

--- a/app/block/listener.go
+++ b/app/block/listener.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"log"
 	"runtime"
-	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -20,7 +18,7 @@ import (
 // SubscribeToNewBlocks - Listen for event when new block header is
 // available, then fetch block content ( including all transactions )
 // in different worker
-func SubscribeToNewBlocks(connection *d.BlockChainNodeConnection, _db *gorm.DB, _lock *sync.Mutex, _synced *d.SyncState, redis *d.RedisInfo) {
+func SubscribeToNewBlocks(connection *d.BlockChainNodeConnection, _db *gorm.DB, status *d.StatusHolder, redis *d.RedisInfo) {
 	headerChan := make(chan *types.Header)
 
 	subs, err := connection.Websocket.SubscribeNewHead(context.Background(), headerChan)
@@ -53,9 +51,7 @@ func SubscribeToNewBlocks(connection *d.BlockChainNodeConnection, _db *gorm.DB, 
 			if first {
 
 				// Starting now, to be used for calculating system performance, uptime etc.
-				_lock.Lock()
-				_synced.StartedAt = time.Now().UTC()
-				_lock.Unlock()
+				status.SetStartedAt()
 
 				// If historical data query features are enabled
 				// only then we need to sync to latest state of block chain
@@ -71,12 +67,12 @@ func SubscribeToNewBlocks(connection *d.BlockChainNodeConnection, _db *gorm.DB, 
 					// So, it'll check & decide whether persisting again is required or not
 					//
 					// This backward traversal mechanism gives us more recent blockchain happenings to cover
-					go SyncBlocksByRange(connection.RPC, _db, redis, header.Number.Uint64()-1, currentHighestBlockNumber, _lock, _synced)
+					go SyncBlocksByRange(connection.RPC, _db, redis, header.Number.Uint64()-1, currentHighestBlockNumber, status)
 
 					// Starting go routine for fetching blocks `ette` failed to process in previous attempt
 					//
 					// Uses Redis backed queue for fetching pending block hash & retries
-					go retryBlockFetching(connection.RPC, _db, redis, _lock, _synced)
+					go retryBlockFetching(connection.RPC, _db, redis, status)
 
 					// Making sure on when next latest block header is received, it'll not
 					// start another syncer
@@ -104,8 +100,7 @@ func SubscribeToNewBlocks(connection *d.BlockChainNodeConnection, _db *gorm.DB, 
 						blockNumber,
 						_db,
 						redis,
-						_lock,
-						_synced)
+						status)
 
 				})
 

--- a/app/block/pack_block.go
+++ b/app/block/pack_block.go
@@ -1,0 +1,32 @@
+package block
+
+import (
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/itzmeanjan/ette/app/db"
+)
+
+// BuildPackedBlock - Builds struct holding whole block data i.e.
+// block header, block body i.e. tx(s), event log(s)
+func BuildPackedBlock(block *types.Block, txs *db.PackedTransactions) *db.PackedBlock {
+
+	packedBlock := &db.PackedBlock{}
+
+	packedBlock.Block = &db.Blocks{
+		Hash:                block.Hash().Hex(),
+		Number:              block.NumberU64(),
+		Time:                block.Time(),
+		ParentHash:          block.ParentHash().Hex(),
+		Difficulty:          block.Difficulty().String(),
+		GasUsed:             block.GasUsed(),
+		GasLimit:            block.GasLimit(),
+		Nonce:               block.Nonce(),
+		Miner:               block.Coinbase().Hex(),
+		Size:                float64(block.Size()),
+		TransactionRootHash: block.TxHash().Hex(),
+		ReceiptRootHash:     block.ReceiptHash().Hex(),
+	}
+	packedBlock.Txs = txs
+
+	return packedBlock
+
+}

--- a/app/block/pack_block.go
+++ b/app/block/pack_block.go
@@ -7,7 +7,7 @@ import (
 
 // BuildPackedBlock - Builds struct holding whole block data i.e.
 // block header, block body i.e. tx(s), event log(s)
-func BuildPackedBlock(block *types.Block, txs *db.PackedTransactions) *db.PackedBlock {
+func BuildPackedBlock(block *types.Block, txs []*db.PackedTransaction) *db.PackedBlock {
 
 	packedBlock := &db.PackedBlock{}
 
@@ -25,7 +25,7 @@ func BuildPackedBlock(block *types.Block, txs *db.PackedTransactions) *db.Packed
 		TransactionRootHash: block.TxHash().Hex(),
 		ReceiptRootHash:     block.ReceiptHash().Hex(),
 	}
-	packedBlock.Txs = txs
+	packedBlock.Transactions = txs
 
 	return packedBlock
 

--- a/app/block/pack_tx.go
+++ b/app/block/pack_tx.go
@@ -1,0 +1,67 @@
+package block
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	c "github.com/itzmeanjan/ette/app/common"
+	"github.com/itzmeanjan/ette/app/db"
+)
+
+// BuildPackedTx - Putting all information, `ette` will keep for one tx
+// into a single structure, so that it becomes easier to pass to & from functions
+func BuildPackedTx(tx *types.Transaction, sender common.Address, receipt *types.Receipt) *db.PackedTransaction {
+
+	packedTx := &db.PackedTransaction{}
+
+	if tx.To() == nil {
+
+		packedTx.Tx = db.Transactions{
+			Hash:      tx.Hash().Hex(),
+			From:      sender.Hex(),
+			Contract:  receipt.ContractAddress.Hex(),
+			Value:     tx.Value().String(),
+			Data:      tx.Data(),
+			Gas:       tx.Gas(),
+			GasPrice:  tx.GasPrice().String(),
+			Cost:      tx.Cost().String(),
+			Nonce:     tx.Nonce(),
+			State:     receipt.Status,
+			BlockHash: receipt.BlockHash.Hex(),
+		}
+
+	} else {
+
+		packedTx.Tx = db.Transactions{
+			Hash:      tx.Hash().Hex(),
+			From:      sender.Hex(),
+			To:        tx.To().Hex(),
+			Value:     tx.Value().String(),
+			Data:      tx.Data(),
+			Gas:       tx.Gas(),
+			GasPrice:  tx.GasPrice().String(),
+			Cost:      tx.Cost().String(),
+			Nonce:     tx.Nonce(),
+			State:     receipt.Status,
+			BlockHash: receipt.BlockHash.Hex(),
+		}
+
+	}
+
+	packedTx.Events = make([]*db.Events, len(receipt.Logs))
+
+	for k, v := range receipt.Logs {
+
+		packedTx.Events[k] = &db.Events{
+			Origin:          v.Address.Hex(),
+			Index:           v.Index,
+			Topics:          c.StringifyEventTopics(v.Topics),
+			Data:            v.Data,
+			TransactionHash: v.TxHash.Hex(),
+			BlockHash:       v.BlockHash.Hex(),
+		}
+
+	}
+
+	return packedTx
+
+}

--- a/app/block/pack_tx.go
+++ b/app/block/pack_tx.go
@@ -15,7 +15,7 @@ func BuildPackedTx(tx *types.Transaction, sender common.Address, receipt *types.
 
 	if tx.To() == nil {
 
-		packedTx.Tx = db.Transactions{
+		packedTx.Tx = &db.Transactions{
 			Hash:      tx.Hash().Hex(),
 			From:      sender.Hex(),
 			Contract:  receipt.ContractAddress.Hex(),
@@ -31,7 +31,7 @@ func BuildPackedTx(tx *types.Transaction, sender common.Address, receipt *types.
 
 	} else {
 
-		packedTx.Tx = db.Transactions{
+		packedTx.Tx = &db.Transactions{
 			Hash:      tx.Hash().Hex(),
 			From:      sender.Hex(),
 			To:        tx.To().Hex(),

--- a/app/block/publish.go
+++ b/app/block/publish.go
@@ -11,6 +11,28 @@ import (
 	d "github.com/itzmeanjan/ette/app/data"
 )
 
+// PublishBlock - Attempts to publish block data to Redis pubsub channel
+func PublishBlock(block *types.Block, redis *d.RedisInfo) {
+
+	if err := redis.Client.Publish(context.Background(), "block", &d.Block{
+		Hash:                block.Hash().Hex(),
+		Number:              block.NumberU64(),
+		Time:                block.Time(),
+		ParentHash:          block.ParentHash().Hex(),
+		Difficulty:          block.Difficulty().String(),
+		GasUsed:             block.GasUsed(),
+		GasLimit:            block.GasLimit(),
+		Nonce:               block.Nonce(),
+		Miner:               block.Coinbase().Hex(),
+		Size:                float64(block.Size()),
+		TransactionRootHash: block.TxHash().Hex(),
+		ReceiptRootHash:     block.ReceiptHash().Hex(),
+	}).Err(); err != nil {
+		log.Print(color.Red.Sprintf("[!] Failed to publish block %d in channel : %s", block.NumberU64(), err.Error()))
+	}
+
+}
+
 // PublishTx - Publishes tx & events in tx, related data to respective
 // Redis pubsub channel
 func PublishTx(blockNumber uint64, tx *types.Transaction, sender common.Address, receipt *types.Receipt, redis *d.RedisInfo) {

--- a/app/block/publish.go
+++ b/app/block/publish.go
@@ -10,67 +10,105 @@ import (
 )
 
 // PublishBlock - Attempts to publish block data to Redis pubsub channel
-func PublishBlock(block *db.Blocks, redis *d.RedisInfo) {
+func PublishBlock(block *db.PackedBlock, redis *d.RedisInfo) {
 
 	if err := redis.Client.Publish(context.Background(), "block", &d.Block{
-		Hash:                block.Hash,
-		Number:              block.Number,
-		Time:                block.Time,
-		ParentHash:          block.ParentHash,
-		Difficulty:          block.Difficulty,
-		GasUsed:             block.GasUsed,
-		GasLimit:            block.GasLimit,
-		Nonce:               block.Nonce,
-		Miner:               block.Miner,
-		Size:                block.Size,
-		TransactionRootHash: block.TransactionRootHash,
-		ReceiptRootHash:     block.ReceiptRootHash,
+		Hash:                block.Block.Hash,
+		Number:              block.Block.Number,
+		Time:                block.Block.Time,
+		ParentHash:          block.Block.ParentHash,
+		Difficulty:          block.Block.Difficulty,
+		GasUsed:             block.Block.GasUsed,
+		GasLimit:            block.Block.GasLimit,
+		Nonce:               block.Block.Nonce,
+		Miner:               block.Block.Miner,
+		Size:                block.Block.Size,
+		TransactionRootHash: block.Block.TransactionRootHash,
+		ReceiptRootHash:     block.Block.ReceiptRootHash,
 	}).Err(); err != nil {
-		log.Print(color.Red.Sprintf("[!] Failed to publish block %d in channel : %s", block.Number, err.Error()))
+		log.Print(color.Red.Sprintf("[!] Failed to publish block %d in channel : %s", block.Block.Number, err.Error()))
+		return
+	}
+
+	PublishTxs(block.Block.Number, block.Transactions, redis)
+
+}
+
+// PublishTxs - Publishes all transactions in a block to redis pubsub
+// channel
+func PublishTxs(blockNumber uint64, txs []*db.PackedTransaction, redis *d.RedisInfo) {
+
+	if txs == nil {
+		return
+	}
+
+	for _, t := range txs {
+		PublishTx(blockNumber, t, redis)
 	}
 
 }
 
 // PublishTx - Publishes tx & events in tx, related data to respective
 // Redis pubsub channel
-func PublishTx(blockNumber uint64, tx *db.Transactions, redis *d.RedisInfo) {
+func PublishTx(blockNumber uint64, tx *db.PackedTransaction, redis *d.RedisInfo) {
+
+	if tx == nil {
+		return
+	}
 
 	var pTx *d.Transaction
 
-	if tx.To == "" {
+	if tx.Tx.To == "" {
 		// This is a contract creation tx
 		pTx = &d.Transaction{
-			Hash:      tx.Hash,
-			From:      tx.From,
-			Contract:  tx.Contract,
-			Value:     tx.Value,
-			Data:      tx.Data,
-			Gas:       tx.Gas,
-			GasPrice:  tx.GasPrice,
-			Cost:      tx.Cost,
-			Nonce:     tx.Nonce,
-			State:     tx.State,
-			BlockHash: tx.BlockHash,
+			Hash:      tx.Tx.Hash,
+			From:      tx.Tx.From,
+			Contract:  tx.Tx.Contract,
+			Value:     tx.Tx.Value,
+			Data:      tx.Tx.Data,
+			Gas:       tx.Tx.Gas,
+			GasPrice:  tx.Tx.GasPrice,
+			Cost:      tx.Tx.Cost,
+			Nonce:     tx.Tx.Nonce,
+			State:     tx.Tx.State,
+			BlockHash: tx.Tx.BlockHash,
 		}
 	} else {
 		// This is a normal tx, so we keep contract field empty
 		pTx = &d.Transaction{
-			Hash:      tx.Hash,
-			From:      tx.From,
-			To:        tx.To,
-			Value:     tx.Value,
-			Data:      tx.Data,
-			Gas:       tx.Gas,
-			GasPrice:  tx.GasPrice,
-			Cost:      tx.Cost,
-			Nonce:     tx.Nonce,
-			State:     tx.State,
-			BlockHash: tx.BlockHash,
+			Hash:      tx.Tx.Hash,
+			From:      tx.Tx.From,
+			To:        tx.Tx.To,
+			Value:     tx.Tx.Value,
+			Data:      tx.Tx.Data,
+			Gas:       tx.Tx.Gas,
+			GasPrice:  tx.Tx.GasPrice,
+			Cost:      tx.Tx.Cost,
+			Nonce:     tx.Tx.Nonce,
+			State:     tx.Tx.State,
+			BlockHash: tx.Tx.BlockHash,
 		}
 	}
 
 	if err := redis.Client.Publish(context.Background(), "transaction", pTx).Err(); err != nil {
 		log.Print(color.Red.Sprintf("[!] Failed to publish transaction from block %d : %s", blockNumber, err.Error()))
+		return
+	}
+
+	PublishEvents(blockNumber, tx.Events, redis)
+
+}
+
+// PublishEvents - Iterate over all events & try to publish them on
+// redis pubsub channel
+func PublishEvents(blockNumber uint64, events []*db.Events, redis *d.RedisInfo) {
+
+	if events == nil {
+		return
+	}
+
+	for _, e := range events {
+		PublishEvent(blockNumber, e, redis)
 	}
 
 }
@@ -79,6 +117,10 @@ func PublishTx(blockNumber uint64, tx *db.Transactions, redis *d.RedisInfo) {
 // and sent to client application, who are interested in this piece of data
 // after applying filter
 func PublishEvent(blockNumber uint64, event *db.Events, redis *d.RedisInfo) {
+
+	if event == nil {
+		return
+	}
 
 	if err := redis.Client.Publish(context.Background(), "event", &d.Event{
 		Origin:          event.Origin,
@@ -89,6 +131,7 @@ func PublishEvent(blockNumber uint64, event *db.Events, redis *d.RedisInfo) {
 		BlockHash:       event.BlockHash,
 	}).Err(); err != nil {
 		log.Print(color.Red.Sprintf("[!] Failed to publish event from block %d : %s", blockNumber, err.Error()))
+		return
 	}
 
 }

--- a/app/block/publish.go
+++ b/app/block/publish.go
@@ -1,0 +1,78 @@
+package block
+
+import (
+	"context"
+	"log"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/gookit/color"
+	c "github.com/itzmeanjan/ette/app/common"
+	d "github.com/itzmeanjan/ette/app/data"
+)
+
+// PublishTx - Publishes tx & events in tx, related data to respective
+// Redis pubsub channel
+func PublishTx(blockNumber uint64, tx *types.Transaction, sender common.Address, receipt *types.Receipt, redis *d.RedisInfo) {
+
+	var pTx *d.Transaction
+
+	if tx.To() == nil {
+		// This is a contract creation tx
+		pTx = &d.Transaction{
+			Hash:      tx.Hash().Hex(),
+			From:      sender.Hex(),
+			Contract:  receipt.ContractAddress.Hex(),
+			Value:     tx.Value().String(),
+			Data:      tx.Data(),
+			Gas:       tx.Gas(),
+			GasPrice:  tx.GasPrice().String(),
+			Cost:      tx.Cost().String(),
+			Nonce:     tx.Nonce(),
+			State:     receipt.Status,
+			BlockHash: receipt.BlockHash.Hex(),
+		}
+	} else {
+		// This is a normal tx, so we keep contract field empty
+		pTx = &d.Transaction{
+			Hash:      tx.Hash().Hex(),
+			From:      sender.Hex(),
+			To:        tx.To().Hex(),
+			Value:     tx.Value().String(),
+			Data:      tx.Data(),
+			Gas:       tx.Gas(),
+			GasPrice:  tx.GasPrice().String(),
+			Cost:      tx.Cost().String(),
+			Nonce:     tx.Nonce(),
+			State:     receipt.Status,
+			BlockHash: receipt.BlockHash.Hex(),
+		}
+	}
+
+	if err := redis.Client.Publish(context.Background(), "transaction", pTx).Err(); err != nil {
+		log.Print(color.Red.Sprintf("[!] Failed to publish transaction from block %d : %s", blockNumber, err.Error()))
+	}
+
+}
+
+// PublishEvents - Publishing event/ log entries to redis pub-sub topic, to be captured by subscribers
+// and sent to client application, who are interested in this piece of data
+// after applying filter
+func PublishEvents(blockNumber uint64, receipt *types.Receipt, redis *d.RedisInfo) {
+
+	for _, v := range receipt.Logs {
+
+		if err := redis.Client.Publish(context.Background(), "event", &d.Event{
+			Origin:          v.Address.Hex(),
+			Index:           v.Index,
+			Topics:          c.StringifyEventTopics(v.Topics),
+			Data:            v.Data,
+			TransactionHash: v.TxHash.Hex(),
+			BlockHash:       v.BlockHash.Hex(),
+		}).Err(); err != nil {
+			log.Print(color.Red.Sprintf("[!] Failed to publish event from block %d : %s", blockNumber, err.Error()))
+		}
+
+	}
+
+}

--- a/app/block/publish.go
+++ b/app/block/publish.go
@@ -4,70 +4,68 @@ import (
 	"context"
 	"log"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/gookit/color"
-	c "github.com/itzmeanjan/ette/app/common"
 	d "github.com/itzmeanjan/ette/app/data"
+	"github.com/itzmeanjan/ette/app/db"
 )
 
 // PublishBlock - Attempts to publish block data to Redis pubsub channel
-func PublishBlock(block *types.Block, redis *d.RedisInfo) {
+func PublishBlock(block *db.Blocks, redis *d.RedisInfo) {
 
 	if err := redis.Client.Publish(context.Background(), "block", &d.Block{
-		Hash:                block.Hash().Hex(),
-		Number:              block.NumberU64(),
-		Time:                block.Time(),
-		ParentHash:          block.ParentHash().Hex(),
-		Difficulty:          block.Difficulty().String(),
-		GasUsed:             block.GasUsed(),
-		GasLimit:            block.GasLimit(),
-		Nonce:               block.Nonce(),
-		Miner:               block.Coinbase().Hex(),
-		Size:                float64(block.Size()),
-		TransactionRootHash: block.TxHash().Hex(),
-		ReceiptRootHash:     block.ReceiptHash().Hex(),
+		Hash:                block.Hash,
+		Number:              block.Number,
+		Time:                block.Time,
+		ParentHash:          block.ParentHash,
+		Difficulty:          block.Difficulty,
+		GasUsed:             block.GasUsed,
+		GasLimit:            block.GasLimit,
+		Nonce:               block.Nonce,
+		Miner:               block.Miner,
+		Size:                block.Size,
+		TransactionRootHash: block.TransactionRootHash,
+		ReceiptRootHash:     block.ReceiptRootHash,
 	}).Err(); err != nil {
-		log.Print(color.Red.Sprintf("[!] Failed to publish block %d in channel : %s", block.NumberU64(), err.Error()))
+		log.Print(color.Red.Sprintf("[!] Failed to publish block %d in channel : %s", block.Number, err.Error()))
 	}
 
 }
 
 // PublishTx - Publishes tx & events in tx, related data to respective
 // Redis pubsub channel
-func PublishTx(blockNumber uint64, tx *types.Transaction, sender common.Address, receipt *types.Receipt, redis *d.RedisInfo) {
+func PublishTx(blockNumber uint64, tx *db.Transactions, redis *d.RedisInfo) {
 
 	var pTx *d.Transaction
 
-	if tx.To() == nil {
+	if tx.To == "" {
 		// This is a contract creation tx
 		pTx = &d.Transaction{
-			Hash:      tx.Hash().Hex(),
-			From:      sender.Hex(),
-			Contract:  receipt.ContractAddress.Hex(),
-			Value:     tx.Value().String(),
-			Data:      tx.Data(),
-			Gas:       tx.Gas(),
-			GasPrice:  tx.GasPrice().String(),
-			Cost:      tx.Cost().String(),
-			Nonce:     tx.Nonce(),
-			State:     receipt.Status,
-			BlockHash: receipt.BlockHash.Hex(),
+			Hash:      tx.Hash,
+			From:      tx.From,
+			Contract:  tx.Contract,
+			Value:     tx.Value,
+			Data:      tx.Data,
+			Gas:       tx.Gas,
+			GasPrice:  tx.GasPrice,
+			Cost:      tx.Cost,
+			Nonce:     tx.Nonce,
+			State:     tx.State,
+			BlockHash: tx.BlockHash,
 		}
 	} else {
 		// This is a normal tx, so we keep contract field empty
 		pTx = &d.Transaction{
-			Hash:      tx.Hash().Hex(),
-			From:      sender.Hex(),
-			To:        tx.To().Hex(),
-			Value:     tx.Value().String(),
-			Data:      tx.Data(),
-			Gas:       tx.Gas(),
-			GasPrice:  tx.GasPrice().String(),
-			Cost:      tx.Cost().String(),
-			Nonce:     tx.Nonce(),
-			State:     receipt.Status,
-			BlockHash: receipt.BlockHash.Hex(),
+			Hash:      tx.Hash,
+			From:      tx.From,
+			To:        tx.To,
+			Value:     tx.Value,
+			Data:      tx.Data,
+			Gas:       tx.Gas,
+			GasPrice:  tx.GasPrice,
+			Cost:      tx.Cost,
+			Nonce:     tx.Nonce,
+			State:     tx.State,
+			BlockHash: tx.BlockHash,
 		}
 	}
 
@@ -77,24 +75,20 @@ func PublishTx(blockNumber uint64, tx *types.Transaction, sender common.Address,
 
 }
 
-// PublishEvents - Publishing event/ log entries to redis pub-sub topic, to be captured by subscribers
+// PublishEvent - Publishing event/ log entry to redis pub-sub topic, to be captured by subscribers
 // and sent to client application, who are interested in this piece of data
 // after applying filter
-func PublishEvents(blockNumber uint64, receipt *types.Receipt, redis *d.RedisInfo) {
+func PublishEvent(blockNumber uint64, event *db.Events, redis *d.RedisInfo) {
 
-	for _, v := range receipt.Logs {
-
-		if err := redis.Client.Publish(context.Background(), "event", &d.Event{
-			Origin:          v.Address.Hex(),
-			Index:           v.Index,
-			Topics:          c.StringifyEventTopics(v.Topics),
-			Data:            v.Data,
-			TransactionHash: v.TxHash.Hex(),
-			BlockHash:       v.BlockHash.Hex(),
-		}).Err(); err != nil {
-			log.Print(color.Red.Sprintf("[!] Failed to publish event from block %d : %s", blockNumber, err.Error()))
-		}
-
+	if err := redis.Client.Publish(context.Background(), "event", &d.Event{
+		Origin:          event.Origin,
+		Index:           event.Index,
+		Topics:          event.Topics,
+		Data:            event.Data,
+		TransactionHash: event.TransactionHash,
+		BlockHash:       event.BlockHash,
+	}).Err(); err != nil {
+		log.Print(color.Red.Sprintf("[!] Failed to publish event from block %d : %s", blockNumber, err.Error()))
 	}
 
 }

--- a/app/block/retry.go
+++ b/app/block/retry.go
@@ -61,7 +61,7 @@ func retryBlockFetching(client *ethclient.Client, _db *gorm.DB, redis *data.Redi
 		func(blockNumber uint64) {
 			wp.Submit(func() {
 
-				fetchBlockByNumber(client,
+				FetchBlockByNumber(client,
 					parsedBlockNumber,
 					_db,
 					redis,

--- a/app/block/retry.go
+++ b/app/block/retry.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"runtime"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -23,7 +22,7 @@ import (
 // Sleeps for 1000 milliseconds
 //
 // Keeps repeating
-func retryBlockFetching(client *ethclient.Client, _db *gorm.DB, redis *data.RedisInfo, _lock *sync.Mutex, _synced *d.SyncState) {
+func retryBlockFetching(client *ethclient.Client, _db *gorm.DB, redis *data.RedisInfo, status *d.StatusHolder) {
 	sleep := func() {
 		time.Sleep(time.Duration(500) * time.Millisecond)
 	}
@@ -66,8 +65,7 @@ func retryBlockFetching(client *ethclient.Client, _db *gorm.DB, redis *data.Redi
 					parsedBlockNumber,
 					_db,
 					redis,
-					_lock,
-					_synced)
+					status)
 
 			})
 		}(parsedBlockNumber)

--- a/app/block/retry.go
+++ b/app/block/retry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gammazero/workerpool"
 	"github.com/go-redis/redis/v8"
 	"github.com/gookit/color"
+	cfg "github.com/itzmeanjan/ette/app/config"
 	d "github.com/itzmeanjan/ette/app/data"
 	"gorm.io/gorm"
 )
@@ -28,7 +29,7 @@ func retryBlockFetching(client *ethclient.Client, _db *gorm.DB, redisClient *red
 
 	// Creating worker pool and submitting jobs as soon as it's determined
 	// there's `to be processed` blocks in retry queue
-	wp := workerpool.New(runtime.NumCPU())
+	wp := workerpool.New(runtime.NumCPU() * int(cfg.GetConcurrencyFactor()))
 	defer wp.Stop()
 
 	for {

--- a/app/block/retry.go
+++ b/app/block/retry.go
@@ -23,7 +23,7 @@ import (
 // Keeps repeating
 func retryBlockFetching(client *ethclient.Client, _db *gorm.DB, redisClient *redis.Client, redisKey string, _lock *sync.Mutex, _synced *d.SyncState) {
 	sleep := func() {
-		time.Sleep(time.Duration(1) * time.Second)
+		time.Sleep(time.Duration(500) * time.Millisecond)
 	}
 
 	// Creating worker pool and submitting jobs as soon as it's determined

--- a/app/block/retry.go
+++ b/app/block/retry.go
@@ -47,12 +47,7 @@ func retryBlockFetching(client *ethclient.Client, _db *gorm.DB, redis *data.Redi
 			continue
 		}
 
-		queuedBlocks, err := redis.Client.LLen(context.Background(), redis.QueueName).Result()
-		if err != nil {
-			log.Printf(color.Red.Sprintf("[!] Failed to determine Redis queue length : %s", err.Error()))
-		}
-
-		log.Print(color.Cyan.Sprintf("[~] Retrying block : %d [ In Queue : %d ]", parsedBlockNumber, queuedBlocks))
+		log.Print(color.Cyan.Sprintf("[~] Retrying block : %d [ In Queue : %d ]", parsedBlockNumber, getRetryQueueLength(redis)))
 
 		// Submitting block processor job into pool
 		// which will be picked up & processed
@@ -97,4 +92,16 @@ func checkExistenceOfBlockNumberInRedisQueue(redis *data.RedisInfo, blockNumber 
 	}
 
 	return true
+}
+
+// Returns redis backed retry queue length
+func getRetryQueueLength(redis *data.RedisInfo) int64 {
+
+	blockCount, err := redis.Client.LLen(context.Background(), redis.QueueName).Result()
+	if err != nil {
+		log.Printf(color.Red.Sprintf("[!] Failed to determine Redis queue length : %s", err.Error()))
+	}
+
+	return blockCount
+
 }

--- a/app/block/syncer.go
+++ b/app/block/syncer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gammazero/workerpool"
 	"github.com/go-redis/redis/v8"
 	"github.com/gookit/color"
+	cfg "github.com/itzmeanjan/ette/app/config"
 	d "github.com/itzmeanjan/ette/app/data"
 	"github.com/itzmeanjan/ette/app/db"
 	"gorm.io/gorm"
@@ -27,7 +28,7 @@ func Syncer(client *ethclient.Client, _db *gorm.DB, redisClient *redis.Client, r
 		return
 	}
 
-	wp := workerpool.New(runtime.NumCPU())
+	wp := workerpool.New(runtime.NumCPU() * int(cfg.GetConcurrencyFactor()))
 	i := fromBlock
 	j := toBlock
 

--- a/app/block/syncer.go
+++ b/app/block/syncer.go
@@ -71,7 +71,7 @@ func SyncBlocksByRange(client *ethclient.Client, _db *gorm.DB, redis *data.Redis
 	job := func(wp *workerpool.WorkerPool, j *d.Job) {
 		wp.Submit(func() {
 
-			fetchBlockByNumber(j.Client, j.Block, j.DB, j.Redis, j.Status)
+			FetchBlockByNumber(j.Client, j.Block, j.DB, j.Redis, j.Status)
 
 		})
 	}
@@ -130,7 +130,7 @@ func SyncMissingBlocksInDB(client *ethclient.Client, _db *gorm.DB, redis *data.R
 				block := db.GetBlock(j.DB, j.Block)
 				if block == nil && !checkExistenceOfBlockNumberInRedisQueue(redis, fmt.Sprintf("%d", j.Block)) {
 					// If not found, block fetching cycle is run, for this block
-					fetchBlockByNumber(j.Client, j.Block, j.DB, j.Redis, j.Status)
+					FetchBlockByNumber(j.Client, j.Block, j.DB, j.Redis, j.Status)
 				}
 
 			})

--- a/app/block/transaction.go
+++ b/app/block/transaction.go
@@ -3,7 +3,6 @@ package block
 import (
 	"context"
 	"log"
-	"sync"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -16,7 +15,7 @@ import (
 )
 
 // FetchTransactionByHash - Fetching specific transaction related data & persisting in database
-func FetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *types.Transaction, _db *gorm.DB, redis *d.RedisInfo, publishable bool, _lock *sync.Mutex, _synced *d.SyncState, returnValChan chan bool) {
+func FetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *types.Transaction, _db *gorm.DB, redis *d.RedisInfo, publishable bool, _status *d.StatusHolder, returnValChan chan bool) {
 	receipt, err := client.TransactionReceipt(context.Background(), tx.Hash())
 	if err != nil {
 		log.Print(color.Red.Sprintf("[!] Failed to fetch tx receipt [ block : %d ] : %s", block.NumberU64(), err.Error()))

--- a/app/block/transaction.go
+++ b/app/block/transaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/gookit/color"
@@ -15,13 +16,14 @@ import (
 )
 
 // FetchTransactionByHash - Fetching specific transaction related data & persisting in database
-func FetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *types.Transaction, _db *gorm.DB, redis *d.RedisInfo, publishable bool, _status *d.StatusHolder, returnValChan chan bool) {
+func FetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *types.Transaction, _db *gorm.DB, redis *d.RedisInfo, publishable bool, _status *d.StatusHolder, returnValChan chan *db.PackedTransaction) {
 	receipt, err := client.TransactionReceipt(context.Background(), tx.Hash())
 	if err != nil {
 		log.Print(color.Red.Sprintf("[!] Failed to fetch tx receipt [ block : %d ] : %s", block.NumberU64(), err.Error()))
 
-		// Notifying listener go routine, about status of this executing thread
-		returnValChan <- false
+		// Passing nil, to denote, failed to fetch all tx data
+		// from blockchain node
+		returnValChan <- nil
 		return
 	}
 
@@ -29,33 +31,27 @@ func FetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *ty
 	if err != nil {
 		log.Print(color.Red.Sprintf("[!] Failed to fetch tx sender [ block : %d ] : %s", block.NumberU64(), err.Error()))
 
-		// Notifying listener go routine, about status of this executing thread
-		returnValChan <- false
+		// Passing nil, to denote, failed to fetch all tx data
+		// from blockchain node
+		returnValChan <- nil
 		return
 	}
 
-	status := true
-	if cfg.Get("EtteMode") == "1" || cfg.Get("EtteMode") == "3" {
-
-		// Only if tx storing goes successful, we'll try to store
-		// event log, due to the fact events table has foreign key reference
-		// to tx table
-		if !db.StoreTransaction(_db, tx, receipt, sender) {
-			status = false
-		} else {
-			status = db.StoreEvents(_db, receipt)
-		}
-
-	}
+	// Packing tx related data inside one struct
+	packedTx := BuildPackedTx(tx, sender, receipt)
 
 	// This is not a case when real time data is received, rather this is probably
 	// a sync attempt to latest state of blockchain
 	//
 	// So, in this case, we don't need to publish any data on pubsub channel
 	if !publishable {
-		// Notifying listener go routine, about status of this executing thread
-		returnValChan <- status
+
+		// Passing all tx related data to listener go routine
+		// so that it can attempt to store whole block data
+		// into database
+		returnValChan <- packedTx
 		return
+
 	}
 
 	if cfg.Get("EtteMode") == "2" || cfg.Get("EtteMode") == "3" {
@@ -119,5 +115,64 @@ func FetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *ty
 	}
 
 	// Notifying listener go routine, about status of this executing thread
-	returnValChan <- status
+	returnValChan <- packedTx
+}
+
+// BuildPackedTx - Putting all information, `ette` will keep for one tx
+// into a single structure, so that it becomes easier to pass to & from functions
+func BuildPackedTx(tx *types.Transaction, sender common.Address, receipt *types.Receipt) *db.PackedTransaction {
+
+	packedTx := &db.PackedTransaction{}
+
+	if tx.To() == nil {
+
+		packedTx.Tx = db.Transactions{
+			Hash:      tx.Hash().Hex(),
+			From:      sender.Hex(),
+			Contract:  receipt.ContractAddress.Hex(),
+			Value:     tx.Value().String(),
+			Data:      tx.Data(),
+			Gas:       tx.Gas(),
+			GasPrice:  tx.GasPrice().String(),
+			Cost:      tx.Cost().String(),
+			Nonce:     tx.Nonce(),
+			State:     receipt.Status,
+			BlockHash: receipt.BlockHash.Hex(),
+		}
+
+	} else {
+
+		packedTx.Tx = db.Transactions{
+			Hash:      tx.Hash().Hex(),
+			From:      sender.Hex(),
+			To:        tx.To().Hex(),
+			Value:     tx.Value().String(),
+			Data:      tx.Data(),
+			Gas:       tx.Gas(),
+			GasPrice:  tx.GasPrice().String(),
+			Cost:      tx.Cost().String(),
+			Nonce:     tx.Nonce(),
+			State:     receipt.Status,
+			BlockHash: receipt.BlockHash.Hex(),
+		}
+
+	}
+
+	packedTx.Events = make([]*db.Events, len(receipt.Logs))
+
+	for k, v := range receipt.Logs {
+
+		packedTx.Events[k] = &db.Events{
+			Origin:          v.Address.Hex(),
+			Index:           v.Index,
+			Topics:          c.StringifyEventTopics(v.Topics),
+			Data:            v.Data,
+			TransactionHash: v.TxHash.Hex(),
+			BlockHash:       v.BlockHash.Hex(),
+		}
+
+	}
+
+	return packedTx
+
 }

--- a/app/block/transaction.go
+++ b/app/block/transaction.go
@@ -15,8 +15,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// Fetching specific transaction related data & persisting in database
-func fetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *types.Transaction, _db *gorm.DB, redis *d.RedisInfo, publishable bool, _lock *sync.Mutex, _synced *d.SyncState, returnValChan chan bool) {
+// FetchTransactionByHash - Fetching specific transaction related data & persisting in database
+func FetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *types.Transaction, _db *gorm.DB, redis *d.RedisInfo, publishable bool, _lock *sync.Mutex, _synced *d.SyncState, returnValChan chan bool) {
 	receipt, err := client.TransactionReceipt(context.Background(), tx.Hash())
 	if err != nil {
 		log.Print(color.Red.Sprintf("[!] Failed to fetch tx receipt [ block : %d ] : %s", block.NumberU64(), err.Error()))

--- a/app/block/transaction.go
+++ b/app/block/transaction.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"log"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/gookit/color"
-	c "github.com/itzmeanjan/ette/app/common"
 	cfg "github.com/itzmeanjan/ette/app/config"
 	d "github.com/itzmeanjan/ette/app/data"
 	"github.com/itzmeanjan/ette/app/db"
@@ -55,7 +53,7 @@ func FetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *ty
 		return
 	}
 
-	// Checking whether `ette` is being run in real-time data delivery
+	// Checking whether `ette` is running in real-time data delivery
 	// mode or not
 	//
 	// If yes & this tx, event log data can be published,
@@ -64,127 +62,7 @@ func FetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *ty
 	// topic of their interest
 	if cfg.Get("EtteMode") == "2" || cfg.Get("EtteMode") == "3" {
 		PublishTx(block.NumberU64(), tx, sender, receipt, redis)
-	}
-
-}
-
-// BuildPackedTx - Putting all information, `ette` will keep for one tx
-// into a single structure, so that it becomes easier to pass to & from functions
-func BuildPackedTx(tx *types.Transaction, sender common.Address, receipt *types.Receipt) *db.PackedTransaction {
-
-	packedTx := &db.PackedTransaction{}
-
-	if tx.To() == nil {
-
-		packedTx.Tx = db.Transactions{
-			Hash:      tx.Hash().Hex(),
-			From:      sender.Hex(),
-			Contract:  receipt.ContractAddress.Hex(),
-			Value:     tx.Value().String(),
-			Data:      tx.Data(),
-			Gas:       tx.Gas(),
-			GasPrice:  tx.GasPrice().String(),
-			Cost:      tx.Cost().String(),
-			Nonce:     tx.Nonce(),
-			State:     receipt.Status,
-			BlockHash: receipt.BlockHash.Hex(),
-		}
-
-	} else {
-
-		packedTx.Tx = db.Transactions{
-			Hash:      tx.Hash().Hex(),
-			From:      sender.Hex(),
-			To:        tx.To().Hex(),
-			Value:     tx.Value().String(),
-			Data:      tx.Data(),
-			Gas:       tx.Gas(),
-			GasPrice:  tx.GasPrice().String(),
-			Cost:      tx.Cost().String(),
-			Nonce:     tx.Nonce(),
-			State:     receipt.Status,
-			BlockHash: receipt.BlockHash.Hex(),
-		}
-
-	}
-
-	packedTx.Events = make([]*db.Events, len(receipt.Logs))
-
-	for k, v := range receipt.Logs {
-
-		packedTx.Events[k] = &db.Events{
-			Origin:          v.Address.Hex(),
-			Index:           v.Index,
-			Topics:          c.StringifyEventTopics(v.Topics),
-			Data:            v.Data,
-			TransactionHash: v.TxHash.Hex(),
-			BlockHash:       v.BlockHash.Hex(),
-		}
-
-	}
-
-	return packedTx
-
-}
-
-// PublishTx - Publishes tx & events in tx, related data to respective
-// Redis pubsub channel
-func PublishTx(blockNumber uint64, tx *types.Transaction, sender common.Address, receipt *types.Receipt, redis *d.RedisInfo) {
-
-	var pTx *d.Transaction
-
-	if tx.To() == nil {
-		// This is a contract creation tx
-		pTx = &d.Transaction{
-			Hash:      tx.Hash().Hex(),
-			From:      sender.Hex(),
-			Contract:  receipt.ContractAddress.Hex(),
-			Value:     tx.Value().String(),
-			Data:      tx.Data(),
-			Gas:       tx.Gas(),
-			GasPrice:  tx.GasPrice().String(),
-			Cost:      tx.Cost().String(),
-			Nonce:     tx.Nonce(),
-			State:     receipt.Status,
-			BlockHash: receipt.BlockHash.Hex(),
-		}
-	} else {
-		// This is a normal tx, so we keep contract field empty
-		pTx = &d.Transaction{
-			Hash:      tx.Hash().Hex(),
-			From:      sender.Hex(),
-			To:        tx.To().Hex(),
-			Value:     tx.Value().String(),
-			Data:      tx.Data(),
-			Gas:       tx.Gas(),
-			GasPrice:  tx.GasPrice().String(),
-			Cost:      tx.Cost().String(),
-			Nonce:     tx.Nonce(),
-			State:     receipt.Status,
-			BlockHash: receipt.BlockHash.Hex(),
-		}
-	}
-
-	if err := redis.Client.Publish(context.Background(), "transaction", pTx).Err(); err != nil {
-		log.Print(color.Red.Sprintf("[!] Failed to publish transaction from block %d : %s", blockNumber, err.Error()))
-	}
-
-	// Publishing event/ log entries to redis pub-sub topic, to be captured by subscribers
-	// and sent to client application, who are interested in this piece of data
-	// after applying filter
-	for _, v := range receipt.Logs {
-
-		if err := redis.Client.Publish(context.Background(), "event", &d.Event{
-			Origin:          v.Address.Hex(),
-			Index:           v.Index,
-			Topics:          c.StringifyEventTopics(v.Topics),
-			Data:            v.Data,
-			TransactionHash: v.TxHash.Hex(),
-			BlockHash:       v.BlockHash.Hex(),
-		}).Err(); err != nil {
-			log.Print(color.Red.Sprintf("[!] Failed to publish event from block %d : %s", blockNumber, err.Error()))
-		}
-
+		PublishEvents(block.NumberU64(), receipt, redis)
 	}
 
 }

--- a/app/block/transaction.go
+++ b/app/block/transaction.go
@@ -15,8 +15,11 @@ import (
 	"gorm.io/gorm"
 )
 
-// FetchTransactionByHash - Fetching specific transaction related data & persisting in database
+// FetchTransactionByHash - Fetching specific transaction related data, tries to publish data if required
+// & lets listener go routine know about all tx, event data it collected while processing this tx,
+// which will be attempted to be stored in database
 func FetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *types.Transaction, _db *gorm.DB, redis *d.RedisInfo, publishable bool, _status *d.StatusHolder, returnValChan chan *db.PackedTransaction) {
+
 	receipt, err := client.TransactionReceipt(context.Background(), tx.Hash())
 	if err != nil {
 		log.Print(color.Red.Sprintf("[!] Failed to fetch tx receipt [ block : %d ] : %s", block.NumberU64(), err.Error()))
@@ -37,85 +40,32 @@ func FetchTransactionByHash(client *ethclient.Client, block *types.Block, tx *ty
 		return
 	}
 
-	// Packing tx related data inside one struct
-	packedTx := BuildPackedTx(tx, sender, receipt)
+	// Passing all tx related data to listener go routine
+	// so that it can attempt to store whole block data
+	// into database
+	defer func() {
+		returnValChan <- BuildPackedTx(tx, sender, receipt)
+	}()
 
 	// This is not a case when real time data is received, rather this is probably
 	// a sync attempt to latest state of blockchain
 	//
 	// So, in this case, we don't need to publish any data on pubsub channel
 	if !publishable {
-
-		// Passing all tx related data to listener go routine
-		// so that it can attempt to store whole block data
-		// into database
-		returnValChan <- packedTx
 		return
-
 	}
 
+	// Checking whether `ette` is being run in real-time data delivery
+	// mode or not
+	//
+	// If yes & this tx, event log data can be published,
+	// we'll try to publish data to redis pubsub channel
+	// which will be eventually broadcasted to all clients subscribed to
+	// topic of their interest
 	if cfg.Get("EtteMode") == "2" || cfg.Get("EtteMode") == "3" {
-
-		var _publishTx *d.Transaction
-
-		if tx.To() == nil {
-			// This is a contract creation tx
-			_publishTx = &d.Transaction{
-				Hash:      tx.Hash().Hex(),
-				From:      sender.Hex(),
-				Contract:  receipt.ContractAddress.Hex(),
-				Value:     tx.Value().String(),
-				Data:      tx.Data(),
-				Gas:       tx.Gas(),
-				GasPrice:  tx.GasPrice().String(),
-				Cost:      tx.Cost().String(),
-				Nonce:     tx.Nonce(),
-				State:     receipt.Status,
-				BlockHash: receipt.BlockHash.Hex(),
-			}
-		} else {
-			// This is a normal tx, so we keep contract field empty
-			_publishTx = &d.Transaction{
-				Hash:      tx.Hash().Hex(),
-				From:      sender.Hex(),
-				To:        tx.To().Hex(),
-				Value:     tx.Value().String(),
-				Data:      tx.Data(),
-				Gas:       tx.Gas(),
-				GasPrice:  tx.GasPrice().String(),
-				Cost:      tx.Cost().String(),
-				Nonce:     tx.Nonce(),
-				State:     receipt.Status,
-				BlockHash: receipt.BlockHash.Hex(),
-			}
-		}
-
-		if err := redis.Client.Publish(context.Background(), "transaction", _publishTx).Err(); err != nil {
-			log.Print(color.Red.Sprintf("[!] Failed to publish transaction from block %d : %s", block.NumberU64(), err.Error()))
-		}
-
-		// Publishing event/ log entries to redis pub-sub topic, to be captured by subscribers
-		// and sent to client application, who are interested in this piece of data
-		// after applying filter
-		for _, v := range receipt.Logs {
-
-			if err := redis.Client.Publish(context.Background(), "event", &d.Event{
-				Origin:          v.Address.Hex(),
-				Index:           v.Index,
-				Topics:          c.StringifyEventTopics(v.Topics),
-				Data:            v.Data,
-				TransactionHash: v.TxHash.Hex(),
-				BlockHash:       v.BlockHash.Hex(),
-			}).Err(); err != nil {
-				log.Print(color.Red.Sprintf("[!] Failed to publish event from block %d : %s", block.NumberU64(), err.Error()))
-			}
-
-		}
-
+		PublishTx(block.NumberU64(), tx, sender, receipt, redis)
 	}
 
-	// Notifying listener go routine, about status of this executing thread
-	returnValChan <- packedTx
 }
 
 // BuildPackedTx - Putting all information, `ette` will keep for one tx
@@ -174,5 +124,67 @@ func BuildPackedTx(tx *types.Transaction, sender common.Address, receipt *types.
 	}
 
 	return packedTx
+
+}
+
+// PublishTx - Publishes tx & events in tx, related data to respective
+// Redis pubsub channel
+func PublishTx(blockNumber uint64, tx *types.Transaction, sender common.Address, receipt *types.Receipt, redis *d.RedisInfo) {
+
+	var pTx *d.Transaction
+
+	if tx.To() == nil {
+		// This is a contract creation tx
+		pTx = &d.Transaction{
+			Hash:      tx.Hash().Hex(),
+			From:      sender.Hex(),
+			Contract:  receipt.ContractAddress.Hex(),
+			Value:     tx.Value().String(),
+			Data:      tx.Data(),
+			Gas:       tx.Gas(),
+			GasPrice:  tx.GasPrice().String(),
+			Cost:      tx.Cost().String(),
+			Nonce:     tx.Nonce(),
+			State:     receipt.Status,
+			BlockHash: receipt.BlockHash.Hex(),
+		}
+	} else {
+		// This is a normal tx, so we keep contract field empty
+		pTx = &d.Transaction{
+			Hash:      tx.Hash().Hex(),
+			From:      sender.Hex(),
+			To:        tx.To().Hex(),
+			Value:     tx.Value().String(),
+			Data:      tx.Data(),
+			Gas:       tx.Gas(),
+			GasPrice:  tx.GasPrice().String(),
+			Cost:      tx.Cost().String(),
+			Nonce:     tx.Nonce(),
+			State:     receipt.Status,
+			BlockHash: receipt.BlockHash.Hex(),
+		}
+	}
+
+	if err := redis.Client.Publish(context.Background(), "transaction", pTx).Err(); err != nil {
+		log.Print(color.Red.Sprintf("[!] Failed to publish transaction from block %d : %s", blockNumber, err.Error()))
+	}
+
+	// Publishing event/ log entries to redis pub-sub topic, to be captured by subscribers
+	// and sent to client application, who are interested in this piece of data
+	// after applying filter
+	for _, v := range receipt.Logs {
+
+		if err := redis.Client.Publish(context.Background(), "event", &d.Event{
+			Origin:          v.Address.Hex(),
+			Index:           v.Index,
+			Topics:          c.StringifyEventTopics(v.Topics),
+			Data:            v.Data,
+			TransactionHash: v.TxHash.Hex(),
+			BlockHash:       v.BlockHash.Hex(),
+		}).Err(); err != nil {
+			log.Print(color.Red.Sprintf("[!] Failed to publish event from block %d : %s", blockNumber, err.Error()))
+		}
+
+	}
 
 }

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -1,6 +1,11 @@
 package config
 
-import "github.com/spf13/viper"
+import (
+	"log"
+	"strconv"
+
+	"github.com/spf13/viper"
+)
 
 // Read - Reading .env file content, during application start up
 func Read(file string) error {
@@ -12,4 +17,22 @@ func Read(file string) error {
 // Get - Get config value by key
 func Get(key string) string {
 	return viper.GetString(key)
+}
+
+// GetConcurrencyFactor - Reads concurrency factor specified in `.env` file, during deployment
+// and returns that number as unsigned integer
+func GetConcurrencyFactor() uint64 {
+
+	factor := Get("ConcurrencyFactor")
+	if factor == "" {
+		return 1
+	}
+
+	parsedFactor, err := strconv.ParseUint(factor, 10, 64)
+	if err != nil {
+		log.Printf("[!] Failed to parse concurrency factor : %s\n", err.Error())
+		return 1
+	}
+
+	return parsedFactor
 }

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -34,5 +34,9 @@ func GetConcurrencyFactor() uint64 {
 		return 1
 	}
 
+	if !(parsedFactor > 0) {
+		return 1
+	}
+
 	return parsedFactor
 }

--- a/app/data/data.go
+++ b/app/data/data.go
@@ -253,3 +253,10 @@ func (e *Events) ToJSON() []byte {
 	return data
 
 }
+
+// PackedTransaction - All data that is stored in a tx, to be passed from
+// tx data fetcher to whole block data persist handler function
+type PackedTransaction struct {
+	Tx     Transaction
+	Events Events
+}

--- a/app/data/data.go
+++ b/app/data/data.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/go-redis/redis/v8"
+	"github.com/itzmeanjan/ette/app/db"
 	"github.com/lib/pq"
 	"gorm.io/gorm"
 )
@@ -257,12 +258,20 @@ func (e *Events) ToJSON() []byte {
 // PackedTransaction - All data that is stored in a tx, to be passed from
 // tx data fetcher to whole block data persist handler function
 type PackedTransaction struct {
-	Tx     Transaction
-	Events Events
+	Tx     db.Transactions
+	Events []*db.Events
 }
 
 // PackedTransactions - All tx(s) present in specific block, to be passed
 // using this structure to block data persist handler function
 type PackedTransactions struct {
 	Txs []*PackedTransaction
+}
+
+// PackedBlock - Whole block data to be persisted in a single
+// database transaction to ensure data consistency, if something
+// goes wrong in mid, whole persisting operation will get reverted
+type PackedBlock struct {
+	Block db.Blocks
+	Txs   *PackedTransactions
 }

--- a/app/data/data.go
+++ b/app/data/data.go
@@ -260,3 +260,9 @@ type PackedTransaction struct {
 	Tx     Transaction
 	Events Events
 }
+
+// PackedTransactions - All tx(s) present in specific block, to be passed
+// using this structure to block data persist handler function
+type PackedTransactions struct {
+	Txs []*PackedTransaction
+}

--- a/app/data/data.go
+++ b/app/data/data.go
@@ -67,6 +67,36 @@ func (s *StatusHolder) IncrementBlocksProcessed() {
 
 }
 
+// BlockCountInDB - Safely reads currently present blocks in database
+func (s *StatusHolder) BlockCountInDB() uint64 {
+
+	s.Mutex.RLock()
+	defer s.Mutex.RUnlock()
+
+	return s.State.BlockCountInDB()
+
+}
+
+// ElapsedTime - Uptime of `ette`
+func (s *StatusHolder) ElapsedTime() time.Duration {
+
+	s.Mutex.RLock()
+	defer s.Mutex.RUnlock()
+
+	return time.Now().UTC().Sub(s.State.StartedAt)
+
+}
+
+// Done - #-of Blocks processed during `ette` uptime i.e. after last time it started
+func (s *StatusHolder) Done() uint64 {
+
+	s.Mutex.RLock()
+	defer s.Mutex.RUnlock()
+
+	return s.State.Done
+
+}
+
 // RedisInfo - Holds redis related information in this struct, to be used
 // when passing to functions as argument
 type RedisInfo struct {
@@ -96,8 +126,7 @@ type Job struct {
 	DB     *gorm.DB
 	Redis  *RedisInfo
 	Block  uint64
-	Lock   *sync.Mutex
-	Synced *SyncState
+	Status *StatusHolder
 }
 
 // BlockChainNodeConnection - Holds network connection object for blockchain nodes

--- a/app/data/data.go
+++ b/app/data/data.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/go-redis/redis/v8"
-	"github.com/itzmeanjan/ette/app/db"
 	"github.com/lib/pq"
 	"gorm.io/gorm"
 )
@@ -253,25 +252,4 @@ func (e *Events) ToJSON() []byte {
 
 	return data
 
-}
-
-// PackedTransaction - All data that is stored in a tx, to be passed from
-// tx data fetcher to whole block data persist handler function
-type PackedTransaction struct {
-	Tx     db.Transactions
-	Events []*db.Events
-}
-
-// PackedTransactions - All tx(s) present in specific block, to be passed
-// using this structure to block data persist handler function
-type PackedTransactions struct {
-	Txs []*PackedTransaction
-}
-
-// PackedBlock - Whole block data to be persisted in a single
-// database transaction to ensure data consistency, if something
-// goes wrong in mid, whole persisting operation will get reverted
-type PackedBlock struct {
-	Block db.Blocks
-	Txs   *PackedTransactions
 }

--- a/app/data/data.go
+++ b/app/data/data.go
@@ -15,6 +15,13 @@ import (
 	"gorm.io/gorm"
 )
 
+// RedisInfo - Holds redis related information in this struct, to be used
+// when passing to functions as argument
+type RedisInfo struct {
+	Client    *redis.Client // using this object `ette` will talk to Redis
+	QueueName string        // retry queue name, for storing block numbers
+}
+
 // ResultStatus - Keeps track of how many operations went successful
 // and how many of them failed
 type ResultStatus struct {

--- a/app/data/data.go
+++ b/app/data/data.go
@@ -40,13 +40,12 @@ func (r ResultStatus) Total() uint64 {
 
 // Job - For running a block fetching job, these are all the information which are required
 type Job struct {
-	Client      *ethclient.Client
-	DB          *gorm.DB
-	RedisClient *redis.Client
-	RedisKey    string
-	Block       uint64
-	Lock        *sync.Mutex
-	Synced      *SyncState
+	Client *ethclient.Client
+	DB     *gorm.DB
+	Redis  *RedisInfo
+	Block  uint64
+	Lock   *sync.Mutex
+	Synced *SyncState
 }
 
 // BlockChainNodeConnection - Holds network connection object for blockchain nodes

--- a/app/db/block.go
+++ b/app/db/block.go
@@ -41,6 +41,18 @@ func StoreBlock(dbWOTx *gorm.DB, block *PackedBlock, status *d.StatusHolder) err
 
 		}
 
+		if block.Transactions == nil {
+
+			// During 👆 flow, if we've really inserted any new block into database
+			// count will get updated
+			if blockInserted {
+				status.IncrementBlocksInserted()
+			}
+
+			return nil
+
+		}
+
 		for _, t := range block.Transactions {
 
 			if err := StoreTransaction(dbWOTx, dbWTx, t.Tx); err != nil {
@@ -58,7 +70,7 @@ func StoreBlock(dbWOTx *gorm.DB, block *PackedBlock, status *d.StatusHolder) err
 		}
 
 		// During 👆 flow, if we've really inserted any new block into database
-		// that count will get updated
+		// count will get updated
 		if blockInserted {
 			status.IncrementBlocksInserted()
 		}

--- a/app/db/block.go
+++ b/app/db/block.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"log"
-	"sync"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	d "github.com/itzmeanjan/ette/app/data"
@@ -14,7 +13,7 @@ import (
 //
 // Also checks equality with existing data, if mismatch found
 // updated with latest data
-func StoreBlock(_db *gorm.DB, _block *types.Block, _lock *sync.Mutex, _synced *d.SyncState) bool {
+func StoreBlock(_db *gorm.DB, _block *types.Block, _status *d.StatusHolder) bool {
 
 	persistedBlock := GetBlock(_db, _block.NumberU64())
 	if persistedBlock == nil {
@@ -25,10 +24,7 @@ func StoreBlock(_db *gorm.DB, _block *types.Block, _lock *sync.Mutex, _synced *d
 		if status {
 			// Trying to safely update inserted block count
 			// -- Critical section of code
-			_lock.Lock()
-			defer _lock.Unlock()
-
-			_synced.NewBlocksInserted++
+			_status.IncrementBlocksInserted()
 			// -- ends here
 		}
 

--- a/app/db/db.go
+++ b/app/db/db.go
@@ -12,7 +12,13 @@ import (
 
 // Connect - Connecting to postgresql database
 func Connect() *gorm.DB {
-	_db, err := gorm.Open(postgres.Open(fmt.Sprintf("postgresql://%s:%s@%s:%s/%s", cfg.Get("DB_USER"), cfg.Get("DB_PASSWORD"), cfg.Get("DB_HOST"), cfg.Get("DB_PORT"), cfg.Get("DB_NAME"))), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	_db, err := gorm.Open(postgres.Open(fmt.Sprintf("postgresql://%s:%s@%s:%s/%s",
+		cfg.Get("DB_USER"), cfg.Get("DB_PASSWORD"), cfg.Get("DB_HOST"),
+		cfg.Get("DB_PORT"), cfg.Get("DB_NAME"))),
+		&gorm.Config{
+			Logger:                 logger.Default.LogMode(logger.Silent),
+			SkipDefaultTransaction: true, // all db writing to be wrapped inside transaction manually
+		})
 	if err != nil {
 		log.Fatalf("[!] Failed to connect to db : %s\n", err.Error())
 	}

--- a/app/db/event.go
+++ b/app/db/event.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"errors"
+
 	"gorm.io/gorm"
 )
 
@@ -14,6 +16,10 @@ import (
 // but while making any change, it'll be definitely protected using transaction
 // to make whole block persistance operation little bit atomic
 func StoreEvent(dbWOTx *gorm.DB, dbWTx *gorm.DB, event *Events) error {
+
+	if event == nil {
+		return errors.New("Empty event received while attempting to persist")
+	}
 
 	persistedEvent := GetEvent(dbWOTx, event.Index, event.BlockHash)
 	if persistedEvent == nil {

--- a/app/db/model.go
+++ b/app/db/model.go
@@ -154,6 +154,27 @@ func (e *Events) SimilarTo(event *Events) bool {
 		e.BlockHash == event.BlockHash
 }
 
+// PackedTransaction - All data that is stored in a tx, to be passed from
+// tx data fetcher to whole block data persist handler function
+type PackedTransaction struct {
+	Tx     Transactions
+	Events []*Events
+}
+
+// PackedTransactions - All tx(s) present in specific block, to be passed
+// using this structure to block data persist handler function
+type PackedTransactions struct {
+	Txs []*PackedTransaction
+}
+
+// PackedBlock - Whole block data to be persisted in a single
+// database transaction to ensure data consistency, if something
+// goes wrong in mid, whole persisting operation will get reverted
+type PackedBlock struct {
+	Block Blocks
+	Txs   *PackedTransactions
+}
+
 // Users - User address & created api key related info, holder table
 type Users struct {
 	Address   string    `gorm:"column:address;type:char(42);not null;index" json:"address"`

--- a/app/db/model.go
+++ b/app/db/model.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/lib/pq"
 )
 
@@ -40,19 +38,19 @@ func (Blocks) TableName() string {
 }
 
 // SimilarTo - Checking whether two blocks are exactly similar or not
-func (b *Blocks) SimilarTo(block *types.Block) bool {
-	return b.Hash == block.Hash().Hex() &&
-		b.Number == block.NumberU64() &&
-		b.Time == block.Time() &&
-		b.ParentHash == block.ParentHash().Hex() &&
-		b.Difficulty == block.Difficulty().String() &&
-		b.GasUsed == block.GasUsed() &&
-		b.GasLimit == block.GasLimit() &&
-		b.Nonce == block.Nonce() &&
-		b.Miner == block.Coinbase().Hex() &&
-		b.Size == float64(block.Size()) &&
-		b.TransactionRootHash == block.TxHash().Hex() &&
-		b.ReceiptRootHash == block.ReceiptHash().Hex()
+func (b *Blocks) SimilarTo(_b *Blocks) bool {
+	return b.Hash == _b.Hash &&
+		b.Number == _b.Number &&
+		b.Time == _b.Time &&
+		b.ParentHash == _b.ParentHash &&
+		b.Difficulty == _b.Difficulty &&
+		b.GasUsed == _b.GasUsed &&
+		b.GasLimit == _b.GasLimit &&
+		b.Nonce == _b.Nonce &&
+		b.Miner == _b.Miner &&
+		b.Size == _b.Size &&
+		b.TransactionRootHash == _b.TransactionRootHash &&
+		b.ReceiptRootHash == _b.ReceiptRootHash
 }
 
 // Transactions - Blockchain transaction holder table model
@@ -78,32 +76,32 @@ func (Transactions) TableName() string {
 }
 
 // SimilarTo - Checking equality of two transactions
-func (t *Transactions) SimilarTo(tx *types.Transaction, txReceipt *types.Receipt, sender common.Address) bool {
-	if tx.To() == nil {
-		return t.Hash == tx.Hash().Hex() &&
-			t.From == sender.Hex() &&
-			t.Contract == txReceipt.ContractAddress.Hex() &&
-			t.Value == tx.Value().String() &&
-			bytes.Compare(t.Data, tx.Data()) == 0 &&
-			t.Gas == tx.Gas() &&
-			t.GasPrice == tx.GasPrice().String() &&
-			t.Cost == tx.Cost().String() &&
-			t.Nonce == tx.Nonce() &&
-			t.State == txReceipt.Status &&
-			t.BlockHash == txReceipt.BlockHash.Hex()
+func (t *Transactions) SimilarTo(_t *Transactions) bool {
+	if _t.To == "" {
+		return t.Hash == _t.Hash &&
+			t.From == _t.From &&
+			t.Contract == _t.Contract &&
+			t.Value == _t.Value &&
+			bytes.Compare(t.Data, _t.Data) == 0 &&
+			t.Gas == _t.Gas &&
+			t.GasPrice == _t.GasPrice &&
+			t.Cost == _t.Cost &&
+			t.Nonce == _t.Nonce &&
+			t.State == _t.State &&
+			t.BlockHash == _t.BlockHash
 	}
 
-	return t.Hash == tx.Hash().Hex() &&
-		t.From == sender.Hex() &&
-		t.To == tx.To().Hex() &&
-		t.Value == tx.Value().String() &&
-		bytes.Compare(t.Data, tx.Data()) == 0 &&
-		t.Gas == tx.Gas() &&
-		t.GasPrice == tx.GasPrice().String() &&
-		t.Cost == tx.Cost().String() &&
-		t.Nonce == tx.Nonce() &&
-		t.State == txReceipt.Status &&
-		t.BlockHash == txReceipt.BlockHash.Hex()
+	return t.Hash == _t.Hash &&
+		t.From == _t.From &&
+		t.To == _t.To &&
+		t.Value == _t.Value &&
+		bytes.Compare(t.Data, _t.Data) == 0 &&
+		t.Gas == _t.Gas &&
+		t.GasPrice == _t.GasPrice &&
+		t.Cost == _t.Cost &&
+		t.Nonce == _t.Nonce &&
+		t.State == _t.State &&
+		t.BlockHash == _t.BlockHash
 }
 
 // Events - Events emitted from smart contracts to be held in this table
@@ -122,7 +120,7 @@ func (Events) TableName() string {
 }
 
 // SimilarTo - Checking equality of two events
-func (e *Events) SimilarTo(event *Events) bool {
+func (e *Events) SimilarTo(_e *Events) bool {
 
 	// Given two string arrays, it'll match it's elements by index & if all of them are same
 	// returns boolean result
@@ -141,17 +139,12 @@ func (e *Events) SimilarTo(event *Events) bool {
 		return matched
 	}
 
-	// Given two byte slices, checks their equality
-	compareByteSlices := func(sliceOne []byte, sliceTwo []byte) bool {
-		return bytes.Compare(e.Data, event.Data) == 0
-	}
-
-	return e.Origin == event.Origin &&
-		e.Index == event.Index &&
-		compareStringArrays(e.Topics, event.Topics) &&
-		compareByteSlices(e.Data, event.Data) &&
-		e.TransactionHash == event.TransactionHash &&
-		e.BlockHash == event.BlockHash
+	return e.Origin == _e.Origin &&
+		e.Index == _e.Index &&
+		compareStringArrays(e.Topics, _e.Topics) &&
+		bytes.Compare(e.Data, _e.Data) == 0 &&
+		e.TransactionHash == _e.TransactionHash &&
+		e.BlockHash == _e.BlockHash
 }
 
 // PackedTransaction - All data that is stored in a tx, to be passed from
@@ -161,18 +154,12 @@ type PackedTransaction struct {
 	Events []*Events
 }
 
-// PackedTransactions - All tx(s) present in specific block, to be passed
-// using this structure to block data persist handler function
-type PackedTransactions struct {
-	Txs []*PackedTransaction
-}
-
 // PackedBlock - Whole block data to be persisted in a single
 // database transaction to ensure data consistency, if something
 // goes wrong in mid, whole persisting operation will get reverted
 type PackedBlock struct {
-	Block *Blocks
-	Txs   *PackedTransactions
+	Block        *Blocks
+	Transactions []*PackedTransaction
 }
 
 // Users - User address & created api key related info, holder table

--- a/app/db/model.go
+++ b/app/db/model.go
@@ -157,7 +157,7 @@ func (e *Events) SimilarTo(event *Events) bool {
 // PackedTransaction - All data that is stored in a tx, to be passed from
 // tx data fetcher to whole block data persist handler function
 type PackedTransaction struct {
-	Tx     Transactions
+	Tx     *Transactions
 	Events []*Events
 }
 
@@ -171,7 +171,7 @@ type PackedTransactions struct {
 // database transaction to ensure data consistency, if something
 // goes wrong in mid, whole persisting operation will get reverted
 type PackedBlock struct {
-	Block Blocks
+	Block *Blocks
 	Txs   *PackedTransactions
 }
 

--- a/app/db/transaction.go
+++ b/app/db/transaction.go
@@ -36,21 +36,12 @@ func GetTransaction(_db *gorm.DB, blkHash string, txHash string) *Transactions {
 	return &tx
 }
 
-// PutTransaction - Persisting transactions present in a block in database
+// PutTransaction - Persisting transaction
 func PutTransaction(tx *gorm.DB, txn *Transactions) error {
-	if err := tx.Create(txn).Error; err != nil {
-		return err
-	}
-
-	return nil
+	return tx.Create(txn).Error
 }
 
-// UpdateTransaction - Updating already persisted transaction in database with
-// new data
+// UpdateTransaction - Updating already persisted transaction
 func UpdateTransaction(tx *gorm.DB, txn *Transactions) error {
-	if err := tx.Where("hash = ? and blockhash = ?", txn.Hash, txn.BlockHash).Updates(txn).Error; err != nil {
-		return err
-	}
-
-	return nil
+	return tx.Where("hash = ? and blockhash = ?", txn.Hash, txn.BlockHash).Updates(txn).Error
 }

--- a/app/db/transaction.go
+++ b/app/db/transaction.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"errors"
+
 	"gorm.io/gorm"
 )
 
@@ -11,6 +13,10 @@ import (
 // i.e. `dbWTx`, which protects helps us in rolling back to previous state, in case of some failure
 // faced during this persistance stage
 func StoreTransaction(dbWOTx *gorm.DB, dbWTx *gorm.DB, tx *Transactions) error {
+
+	if tx == nil {
+		return errors.New("Empty transaction received while attempting to persist")
+	}
 
 	persistedTx := GetTransaction(dbWOTx, tx.BlockHash, tx.BlockHash)
 	if persistedTx == nil {

--- a/app/pubsub/block.go
+++ b/app/pubsub/block.go
@@ -178,6 +178,6 @@ func (b *BlockConsumer) SendData(data interface{}) bool {
 		return false
 	}
 
-	log.Printf("[!] Delivered `block` data to client\n")
+	log.Printf("[+] Delivered `block` data to client\n")
 	return true
 }

--- a/app/pubsub/event.go
+++ b/app/pubsub/event.go
@@ -213,6 +213,6 @@ func (e *EventConsumer) SendData(data interface{}) bool {
 		return false
 	}
 
-	log.Printf("[!] Delivered `event` data to client\n")
+	log.Printf("[+] Delivered `event` data to client\n")
 	return true
 }

--- a/app/pubsub/transaction.go
+++ b/app/pubsub/transaction.go
@@ -231,6 +231,6 @@ func (t *TransactionConsumer) SendData(data interface{}) bool {
 		return false
 	}
 
-	log.Printf("[!] Delivered `transaction` data to client\n")
+	log.Printf("[+] Delivered `transaction` data to client\n")
 	return true
 }

--- a/app/rest/rest.go
+++ b/app/rest/rest.go
@@ -481,6 +481,14 @@ func RunHTTPServer(_db *gorm.DB, _lock *sync.Mutex, _synced *d.SyncState, _redis
 			remaining := (currentBlockNumber + 1) - blockCountInDB
 			elapsed := time.Now().UTC().Sub(_synced.StartedAt)
 
+			if cfg.Get("EtteMode") == "2" {
+				c.JSON(http.StatusOK, gin.H{
+					"processed": _synced.Done,
+					"elapsed":   elapsed.String(),
+				})
+				return
+			}
+
 			status := fmt.Sprintf("%.2f %%", (float64(blockCountInDB)/float64(currentBlockNumber+1))*100)
 			eta := "0s"
 			if remaining > 0 {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,162 +1,13 @@
 {
   "name": "example-ette",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "example-ette",
-      "version": "1.0.0",
-      "license": "CC0-1.0",
-      "dependencies": {
-        "websocket": "^1.0.32"
-      }
-    },
-    "node_modules/bufferutil": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.2.tgz",
-      "integrity": "sha512-AtnG3W6M8B2n4xDQ5R+70EXvOpnXsFYg/AK2yTZd+HQ/oxAdz+GI+DvjmhBw3L0ole+LJ0ngqY4JMbDzkfNzhA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-gyp-build": "^4.2.0"
-      }
-    },
-    "node_modules/d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dependencies": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
-    "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dependencies": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
-    "node_modules/ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "dependencies": {
-        "type": "^2.0.0"
-      }
-    },
-    "node_modules/ext/node_modules/type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-      "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
-    },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-    },
-    "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.3.tgz",
-      "integrity": "sha512-jtJM6fpGv8C1SoH4PtG22pGto6x+Y8uPprW0tw3//gGFhDDTiuksgradgFN6yRayDP4SyZZa6ZMGHLIa17+M8A==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-gyp-build": "^4.2.0"
-      }
-    },
-    "node_modules/websocket": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz",
-      "integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
-      "dependencies": {
-        "bufferutil": "^4.0.1",
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.50",
-        "typedarray-to-buffer": "^3.1.5",
-        "utf-8-validate": "^5.0.2",
-        "yaeti": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
-      "engines": {
-        "node": ">=0.10.32"
-      }
-    }
-  },
   "dependencies": {
     "bufferutil": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.2.tgz",
-      "integrity": "sha512-AtnG3W6M8B2n4xDQ5R+70EXvOpnXsFYg/AK2yTZd+HQ/oxAdz+GI+DvjmhBw3L0ole+LJ0ngqY4JMbDzkfNzhA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
+      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
       "requires": {
         "node-gyp-build": "^4.2.0"
       }
@@ -256,17 +107,17 @@
       }
     },
     "utf-8-validate": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.3.tgz",
-      "integrity": "sha512-jtJM6fpGv8C1SoH4PtG22pGto6x+Y8uPprW0tw3//gGFhDDTiuksgradgFN6yRayDP4SyZZa6ZMGHLIa17+M8A==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
+      "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
       "requires": {
         "node-gyp-build": "^4.2.0"
       }
     },
     "websocket": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz",
-      "integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
+      "integrity": "sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==",
       "requires": {
         "bufferutil": "^4.0.1",
         "debug": "^2.2.0",

--- a/example/package.json
+++ b/example/package.json
@@ -9,6 +9,6 @@
   "author": "Anjan Roy <anjanroy@yandex.com>",
   "license": "CC0-1.0",
   "dependencies": {
-    "websocket": "^1.0.32"
+    "websocket": "^1.0.33"
   }
 }

--- a/views/dashboard.html
+++ b/views/dashboard.html
@@ -172,7 +172,7 @@
 
                     p.innerHTML = e
                     p.style.color = v.enabled ? '#64d9a4' : '#eb8975'
-                    p.ondblclick = e => {  e.preventDefault() }
+                    p.ondblclick = e => {  e.stopPropagation() }
                     
                     card.appendChild(p)
                 })

--- a/views/dashboard.html
+++ b/views/dashboard.html
@@ -117,6 +117,15 @@
 
 }">Create new app</button>
 <script>
+    // Stopping metamask from reloading page, when
+    // when is changed, as we're not really concerned about
+    // which network the user is in
+    //
+    // We're interested in making user sign message of certain format
+    if (typeof ethereum !== undefined) {
+        ethereum.autoRefreshOnNetworkChange = false
+    }
+
     fetch('/v1/dashboard/apps', {
         method: 'GET',
         credentials: 'include',
@@ -163,6 +172,7 @@
 
                     p.innerHTML = e
                     p.style.color = v.enabled ? '#64d9a4' : '#eb8975'
+                    p.ondblclick = e => {  e.preventDefault() }
                     
                     card.appendChild(p)
                 })

--- a/views/index.html
+++ b/views/index.html
@@ -83,4 +83,15 @@
         } else {
             alert('Metamask needs to be installed !')
         } }">Login</div>
+
+<script>
+    // Stopping metamask from reloading page, when
+    // when is changed, as we're not really concerned about
+    // which network the user is in
+    //
+    // We're interested in making user sign message of certain format
+    if (typeof ethereum !== undefined) {
+        ethereum.autoRefreshOnNetworkChange = false
+    }
+</script>
 {{end}}


### PR DESCRIPTION
## changes

- From now on, users can select concurrency level, at which they want `ette` to run
- But it needs to set carefully, putting too high a value, will simply fail it
- When ever concurrent processing to be used, `ette` will create a worker pool of size `concurrenyFactor * #-of-CPUs`
- Lots of job can be submitted but only 👆 jobs can be processed at a time
- This will also be helpful in reducing load on blockchain RPC nodes
- While syncing historical data concurrency factor can be high value ( > 2 )
- Later it can be set to 1, or any unsigned integer value, as user wishes to set
- Updated how database interactions being performed for improving performance
- DB queries to not get wrapped  inside transaction ( default gorm behaviour )
- Only when insertion/ updation being performed, wrapped inside transaction
- From now on for enjoying facility of data consistency, db transaction creation is implementor's responsibilty.
