### PR TITLE
Concurrent safe write on shared network resource

### DIFF
--- a/app/pubsub/block.go
+++ b/app/pubsub/block.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -25,6 +26,7 @@ type BlockConsumer struct {
 	Connection  *websocket.Conn
 	PubSub      *redis.PubSub
 	DB          *gorm.DB
+	Lock        *sync.Mutex
 }
 
 // Subscribe - Subscribe to `block` channel

--- a/app/pubsub/consumption.go
+++ b/app/pubsub/consumption.go
@@ -1,6 +1,8 @@
 package pubsub
 
 import (
+	"sync"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-redis/redis/v8"
 	"github.com/gorilla/websocket"
@@ -19,13 +21,14 @@ type Consumer interface {
 // NewBlockConsumer - Creating one new block data consumer, which will subscribe to block
 // topic & listen for data being published on this channel, which will eventually be
 // delivered to client application over websocket connection
-func NewBlockConsumer(client *redis.Client, conn *websocket.Conn, req *SubscriptionRequest, db *gorm.DB, address common.Address) *BlockConsumer {
+func NewBlockConsumer(client *redis.Client, conn *websocket.Conn, req *SubscriptionRequest, db *gorm.DB, address common.Address, lock *sync.Mutex) *BlockConsumer {
 	consumer := BlockConsumer{
 		Client:      client,
 		Request:     req,
 		UserAddress: address,
 		Connection:  conn,
 		DB:          db,
+		Lock:        lock,
 	}
 
 	consumer.Subscribe()
@@ -38,13 +41,14 @@ func NewBlockConsumer(client *redis.Client, conn *websocket.Conn, req *Subscript
 // topic & listen for data being published on this channel & check whether received data
 // is what, client is interested in or not, which will eventually be
 // delivered to client application over websocket connection
-func NewTransactionConsumer(client *redis.Client, conn *websocket.Conn, req *SubscriptionRequest, db *gorm.DB, address common.Address) *TransactionConsumer {
+func NewTransactionConsumer(client *redis.Client, conn *websocket.Conn, req *SubscriptionRequest, db *gorm.DB, address common.Address, lock *sync.Mutex) *TransactionConsumer {
 	consumer := TransactionConsumer{
 		Client:      client,
 		Request:     req,
 		UserAddress: address,
 		Connection:  conn,
 		DB:          db,
+		Lock:        lock,
 	}
 
 	consumer.Subscribe()
@@ -57,13 +61,14 @@ func NewTransactionConsumer(client *redis.Client, conn *websocket.Conn, req *Sub
 // topic & listen for data being published on this channel & check whether received data
 // is what, client is interested in or not, which will eventually be
 // delivered to client application over websocket connection
-func NewEventConsumer(client *redis.Client, conn *websocket.Conn, req *SubscriptionRequest, db *gorm.DB, address common.Address) *EventConsumer {
+func NewEventConsumer(client *redis.Client, conn *websocket.Conn, req *SubscriptionRequest, db *gorm.DB, address common.Address, lock *sync.Mutex) *EventConsumer {
 	consumer := EventConsumer{
 		Client:      client,
 		Request:     req,
 		UserAddress: address,
 		Connection:  conn,
 		DB:          db,
+		Lock:        lock,
 	}
 
 	consumer.Subscribe()

--- a/app/pubsub/consumption.go
+++ b/app/pubsub/consumption.go
@@ -13,6 +13,7 @@ type Consumer interface {
 	Listen()
 	Send(msg string) bool
 	SendData(data interface{}) bool
+	Unsubscribe()
 }
 
 // NewBlockConsumer - Creating one new block data consumer, which will subscribe to block

--- a/app/pubsub/event.go
+++ b/app/pubsub/event.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -29,6 +30,7 @@ type EventConsumer struct {
 	Connection  *websocket.Conn
 	PubSub      *redis.PubSub
 	DB          *gorm.DB
+	Lock        *sync.Mutex
 }
 
 // Subscribe - Event consumer is subscribing to `event` topic,

--- a/app/pubsub/subscription.go
+++ b/app/pubsub/subscription.go
@@ -48,7 +48,7 @@ func (s *SubscriptionRequest) GetRegex() *regexp.Regexp {
 }
 
 // Topic - Get main topic name to which this client is subscribing to
-// i.e. {block, transaction}
+// i.e. {block, transaction, event}
 func (s *SubscriptionRequest) Topic() string {
 	if strings.HasPrefix(s.Name, "block") {
 		return "block"

--- a/app/pubsub/transaction.go
+++ b/app/pubsub/transaction.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -28,6 +29,7 @@ type TransactionConsumer struct {
 	Connection  *websocket.Conn
 	PubSub      *redis.PubSub
 	DB          *gorm.DB
+	Lock        *sync.Mutex
 }
 
 // Subscribe - Subscribe to `transaction` topic, under which all transaction related data to be published


### PR DESCRIPTION
## changes

- Better subscription management for pubsub topics
   - _Graceful unsubscription when some issue in network connection is detected_
- Concurrent safe write operation to shared network resource
- One websocket connection can be used for subscribing to **N** many of topics i.e. any specific combination of `{block, transaction, event}`
