### PR TITLE
REST & GraphQL API for fetching event log using block hash/ number & log index

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,8 @@ type Transaction {
   from: String!
   to: String!
   contract: String!
+  value: String!
+  data: String!
   gas: String!
   gasPrice: String!
   cost: String!

--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Query Params | Method | Description
 Query Params | Method | Description
 --- | --- | ---
 `blockHash=0x...` | GET | Given blockhash, retrieves all events emitted by tx(s) present in block
+`blockHash=0x...&logIndex=1` | GET | Given blockhash and log index in block, attempts to retrieve associated event
+`blockNumber=123456&logIndex=2` | GET | Given block number and log index in block, attempts to retrieve associated event
 `txHash=0x...` | GET | Given txhash, retrieves all events emitted during execution of this transaction
 `count=50&contract=0x...` | GET | Returns last **x** _( <=50 )_ events emitted by this contract
 `fromBlock=1&toBlock=10&contract=0x...&topic0=0x...&topic1=0x...&topic2=0x...&topic3=0x...` | GET | Finding event(s) emitted from contract within given block range & also matching topic signatures _{0, 1, 2, 3}_
@@ -414,6 +416,8 @@ type Query {
     eventsFromContractWithTopicsByNumberRange(contract: String!, from: String!, to: String!, topics: [String!]!): [Event!]!
     eventsFromContractWithTopicsByTimeRange(contract: String!, from: String!, to: String!, topics: [String!]!): [Event!]!
     lastXEventsFromContract(contract: String!, x: Int!): [Event!]!
+    eventByBlockHashAndLogIndex(hash: String!, index: String!): Event!
+    eventByBlockNumberAndLogIndex(number: String!, index: String!): Event!
 }
 ```
 

--- a/app/db/query.go
+++ b/app/db/query.go
@@ -442,3 +442,25 @@ func GetEventByBlockHashAndLogIndex(db *gorm.DB, hash common.Hash, index uint) *
 	return &event
 
 }
+
+// GetEventByBlockNumberAndLogIndex - Given block number and log index in block
+// return respective event log, if any exists
+func GetEventByBlockNumberAndLogIndex(db *gorm.DB, number uint64, index uint) *data.Event {
+
+	block := GetBlockByNumber(db, number)
+	// seems bad block number or may be `ette`
+	// hasn't synced upto this point or missed
+	// this block some how
+	if block == nil {
+		return nil
+	}
+
+	var event data.Event
+
+	if err := db.Model(&Events{}).Where("blockhash = ? and index = ?", block.Hash, index).First(&event).Error; err != nil {
+		return nil
+	}
+
+	return &event
+
+}

--- a/app/db/query.go
+++ b/app/db/query.go
@@ -428,3 +428,17 @@ func GetLastXEventsFromContract(db *gorm.DB, contract common.Address, x int) *da
 	}
 
 }
+
+// GetEventByBlockHashAndLogIndex - Given block hash and log index in block
+// return respective event log, if any exists
+func GetEventByBlockHashAndLogIndex(db *gorm.DB, hash common.Hash, index uint) *data.Event {
+
+	var event data.Event
+
+	if err := db.Model(&Events{}).Where("blockhash = ? and index = ?", hash.Hex(), index).First(&event).Error; err != nil {
+		return nil
+	}
+
+	return &event
+
+}

--- a/app/rest/graph/generated/generated.go
+++ b/app/rest/graph/generated/generated.go
@@ -73,6 +73,8 @@ type ComplexityRoot struct {
 		BlocksByTimeRange                         func(childComplexity int, from string, to string) int
 		ContractsCreatedFromAccountByNumberRange  func(childComplexity int, account string, from string, to string) int
 		ContractsCreatedFromAccountByTimeRange    func(childComplexity int, account string, from string, to string) int
+		EventByBlockHashAndLogIndex               func(childComplexity int, hash string, index string) int
+		EventByBlockNumberAndLogIndex             func(childComplexity int, number string, index string) int
 		EventsByBlockHash                         func(childComplexity int, hash string) int
 		EventsByTxHash                            func(childComplexity int, hash string) int
 		EventsFromContractByNumberRange           func(childComplexity int, contract string, from string, to string) int
@@ -132,6 +134,8 @@ type QueryResolver interface {
 	EventsFromContractWithTopicsByNumberRange(ctx context.Context, contract string, from string, to string, topics []string) ([]*model.Event, error)
 	EventsFromContractWithTopicsByTimeRange(ctx context.Context, contract string, from string, to string, topics []string) ([]*model.Event, error)
 	LastXEventsFromContract(ctx context.Context, contract string, x int) ([]*model.Event, error)
+	EventByBlockHashAndLogIndex(ctx context.Context, hash string, index string) (*model.Event, error)
+	EventByBlockNumberAndLogIndex(ctx context.Context, number string, index string) (*model.Event, error)
 }
 
 type executableSchema struct {
@@ -346,6 +350,30 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.ContractsCreatedFromAccountByTimeRange(childComplexity, args["account"].(string), args["from"].(string), args["to"].(string)), true
+
+	case "Query.eventByBlockHashAndLogIndex":
+		if e.complexity.Query.EventByBlockHashAndLogIndex == nil {
+			break
+		}
+
+		args, err := ec.field_Query_eventByBlockHashAndLogIndex_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.EventByBlockHashAndLogIndex(childComplexity, args["hash"].(string), args["index"].(string)), true
+
+	case "Query.eventByBlockNumberAndLogIndex":
+		if e.complexity.Query.EventByBlockNumberAndLogIndex == nil {
+			break
+		}
+
+		args, err := ec.field_Query_eventByBlockNumberAndLogIndex_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.EventByBlockNumberAndLogIndex(childComplexity, args["number"].(string), args["index"].(string)), true
 
 	case "Query.eventsByBlockHash":
 		if e.complexity.Query.EventsByBlockHash == nil {
@@ -750,6 +778,8 @@ type Query {
   eventsFromContractWithTopicsByNumberRange(contract: String!, from: String!, to: String!, topics: [String!]!): [Event!]!
   eventsFromContractWithTopicsByTimeRange(contract: String!, from: String!, to: String!, topics: [String!]!): [Event!]!
   lastXEventsFromContract(contract: String!, x: Int!): [Event!]!
+  eventByBlockHashAndLogIndex(hash: String!, index: String!): Event!
+  eventByBlockNumberAndLogIndex(number: String!, index: String!): Event!
 }
 `, BuiltIn: false},
 }
@@ -915,6 +945,54 @@ func (ec *executionContext) field_Query_contractsCreatedFromAccountByTimeRange_a
 		}
 	}
 	args["to"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_eventByBlockHashAndLogIndex_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["hash"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hash"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["hash"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["index"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("index"))
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["index"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_eventByBlockNumberAndLogIndex_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["number"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("number"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["number"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["index"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("index"))
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["index"] = arg1
 	return args, nil
 }
 
@@ -3041,6 +3119,90 @@ func (ec *executionContext) _Query_lastXEventsFromContract(ctx context.Context, 
 	return ec.marshalNEvent2ᚕᚖgithubᚗcomᚋitzmeanjanᚋetteᚋappᚋrestᚋgraphᚋmodelᚐEventᚄ(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Query_eventByBlockHashAndLogIndex(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_eventByBlockHashAndLogIndex_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().EventByBlockHashAndLogIndex(rctx, args["hash"].(string), args["index"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Event)
+	fc.Result = res
+	return ec.marshalNEvent2ᚖgithubᚗcomᚋitzmeanjanᚋetteᚋappᚋrestᚋgraphᚋmodelᚐEvent(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_eventByBlockNumberAndLogIndex(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_eventByBlockNumberAndLogIndex_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().EventByBlockNumberAndLogIndex(rctx, args["number"].(string), args["index"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Event)
+	fc.Result = res
+	return ec.marshalNEvent2ᚖgithubᚗcomᚋitzmeanjanᚋetteᚋappᚋrestᚋgraphᚋmodelᚐEvent(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -5098,6 +5260,34 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				}
 				return res
 			})
+		case "eventByBlockHashAndLogIndex":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_eventByBlockHashAndLogIndex(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "eventByBlockNumberAndLogIndex":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_eventByBlockNumberAndLogIndex(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "__type":
 			out.Values[i] = ec._Query___type(ctx, field)
 		case "__schema":
@@ -5504,6 +5694,10 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNEvent2githubᚗcomᚋitzmeanjanᚋetteᚋappᚋrestᚋgraphᚋmodelᚐEvent(ctx context.Context, sel ast.SelectionSet, v model.Event) graphql.Marshaler {
+	return ec._Event(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNEvent2ᚕᚖgithubᚗcomᚋitzmeanjanᚋetteᚋappᚋrestᚋgraphᚋmodelᚐEventᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Event) graphql.Marshaler {

--- a/app/rest/graph/schema.graphqls
+++ b/app/rest/graph/schema.graphqls
@@ -63,4 +63,6 @@ type Query {
   eventsFromContractWithTopicsByNumberRange(contract: String!, from: String!, to: String!, topics: [String!]!): [Event!]!
   eventsFromContractWithTopicsByTimeRange(contract: String!, from: String!, to: String!, topics: [String!]!): [Event!]!
   lastXEventsFromContract(contract: String!, x: Int!): [Event!]!
+  eventByBlockHashAndLogIndex(hash: String!, index: String!): Event!
+  eventByBlockNumberAndLogIndex(number: String!, index: String!): Event!
 }

--- a/app/rest/graph/schema.resolvers.go
+++ b/app/rest/graph/schema.resolvers.go
@@ -281,6 +281,37 @@ func (r *queryResolver) LastXEventsFromContract(ctx context.Context, contract st
 	return getGraphQLCompatibleEvents(_db.GetLastXEventsFromContract(db, common.HexToAddress(contract), x))
 }
 
+func (r *queryResolver) EventByBlockHashAndLogIndex(ctx context.Context, hash string, index string) (*model.Event, error) {
+
+	if !(strings.HasPrefix(hash, "0x") && len(hash) == 66) {
+		return nil, errors.New("Bad Block Hash")
+	}
+
+	_index, err := strconv.ParseUint(index, 10, 64)
+	if err != nil {
+		return nil, errors.New("Bad Log Index")
+	}
+
+	return getGraphQLCompatibleEvent(_db.GetEventByBlockHashAndLogIndex(db, common.HexToHash(hash), uint(_index)))
+
+}
+
+func (r *queryResolver) EventByBlockNumberAndLogIndex(ctx context.Context, number string, index string) (*model.Event, error) {
+
+	_number, err := strconv.ParseUint(number, 10, 64)
+	if err != nil {
+		return nil, errors.New("Bad Block Number")
+	}
+
+	_index, err := strconv.ParseUint(index, 10, 64)
+	if err != nil {
+		return nil, errors.New("Bad Log Index")
+	}
+
+	return getGraphQLCompatibleEvent(_db.GetEventByBlockNumberAndLogIndex(db, _number, uint(_index)))
+
+}
+
 // Query returns generated.QueryResolver implementation.
 func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 

--- a/app/rest/rest.go
+++ b/app/rest/rest.go
@@ -917,6 +917,33 @@ func RunHTTPServer(_db *gorm.DB, _status *d.StatusHolder, _redisClient *redis.Cl
 			blockHash := c.Query("blockHash")
 			txHash := c.Query("txHash")
 
+			// specific event log which under is requesting
+			logIndex := c.Query("logIndex")
+
+			// Given block hash and log index in block attempts to find out event
+			// which satisfies that criteria
+			if logIndex != "" && strings.HasPrefix(blockHash, "0x") && len(blockHash) == 66 {
+
+				_logIndex, err := strconv.ParseUint(logIndex, 10, 64)
+				if err != nil {
+					c.JSON(http.StatusBadRequest, gin.H{
+						"msg": "Bad log index",
+					})
+					return
+				}
+
+				if event := db.GetEventByBlockHashAndLogIndex(_db, common.HexToHash(blockHash), uint(_logIndex)); event != nil {
+					respondWithJSON(event.ToJSON(), c)
+					return
+				}
+
+				c.JSON(http.StatusNotFound, gin.H{
+					"msg": "Not found",
+				})
+				return
+
+			}
+
 			// Given blockhash, retrieves all events emitted by tx present in block
 			if strings.HasPrefix(blockHash, "0x") && len(blockHash) == 66 {
 

--- a/app/rest/rest.go
+++ b/app/rest/rest.go
@@ -919,6 +919,9 @@ func RunHTTPServer(_db *gorm.DB, _status *d.StatusHolder, _redisClient *redis.Cl
 
 			// specific event log which under is requesting
 			logIndex := c.Query("logIndex")
+			// specific block number which is being asked to look inside
+			// for finding 👆 event log inside block
+			blockNumber := c.Query("blockNumber")
 
 			// Given block hash and log index in block attempts to find out event
 			// which satisfies that criteria
@@ -933,6 +936,38 @@ func RunHTTPServer(_db *gorm.DB, _status *d.StatusHolder, _redisClient *redis.Cl
 				}
 
 				if event := db.GetEventByBlockHashAndLogIndex(_db, common.HexToHash(blockHash), uint(_logIndex)); event != nil {
+					respondWithJSON(event.ToJSON(), c)
+					return
+				}
+
+				c.JSON(http.StatusNotFound, gin.H{
+					"msg": "Not found",
+				})
+				return
+
+			}
+
+			// Given block number and log index in block attempts to find out event
+			// which satisfies that criteria
+			if logIndex != "" && blockNumber != "" {
+
+				_blockNumber, err := strconv.ParseUint(blockNumber, 10, 64)
+				if err != nil {
+					c.JSON(http.StatusBadRequest, gin.H{
+						"msg": "Bad block number",
+					})
+					return
+				}
+
+				_logIndex, err := strconv.ParseUint(logIndex, 10, 64)
+				if err != nil {
+					c.JSON(http.StatusBadRequest, gin.H{
+						"msg": "Bad log index",
+					})
+					return
+				}
+
+				if event := db.GetEventByBlockNumberAndLogIndex(_db, _blockNumber, uint(_logIndex)); event != nil {
 					respondWithJSON(event.ToJSON(), c)
 					return
 				}


### PR DESCRIPTION
## changes

Now `ette` can help you in fetching certain event log given block number/ hash & log index in block. Both REST & GraphQL APIs support it.

```graphql
type Query {
    eventByBlockHashAndLogIndex(hash: String!, index: String!): Event!
    eventByBlockNumberAndLogIndex(number: String!, index: String!): Event!
}
```

In response you'll receive 👇

```graphql
type Event {
  origin: String!
  index: String!
  topics: [String!]!
  data: String!
  txHash: String!
  blockHash: String!
}
```
