### PR TITLE
Imposing rate limiting in `/v1/graphql` endpoint

### DIFF
--- a/app/rest/graph/data.go
+++ b/app/rest/graph/data.go
@@ -113,7 +113,7 @@ func getGraphQLCompatibleBlock(ctx context.Context, block *data.Block, bookKeepi
 }
 
 // Converting block array to graphQL compatible data structure
-func getGraphQLCompatibleBlocks(ctx context.Context, blocks *data.Blocks, bookKeeping bool) ([]*model.Block, error) {
+func getGraphQLCompatibleBlocks(ctx context.Context, blocks *data.Blocks) ([]*model.Block, error) {
 	if blocks == nil {
 		return nil, errors.New("Found nothing")
 	}
@@ -189,7 +189,7 @@ func getGraphQLCompatibleTransaction(ctx context.Context, tx *data.Transaction, 
 }
 
 // Converting transaction array to graphQL compatible data structure
-func getGraphQLCompatibleTransactions(ctx context.Context, tx *data.Transactions, bookKeeping bool) ([]*model.Transaction, error) {
+func getGraphQLCompatibleTransactions(ctx context.Context, tx *data.Transactions) ([]*model.Transaction, error) {
 	if tx == nil {
 		return nil, errors.New("Found nothing")
 	}
@@ -242,7 +242,7 @@ func getGraphQLCompatibleEvent(ctx context.Context, event *data.Event, bookKeepi
 }
 
 // Converting event array to graphQL compatible data structure
-func getGraphQLCompatibleEvents(ctx context.Context, events *data.Events, bookKeeping bool) ([]*model.Event, error) {
+func getGraphQLCompatibleEvents(ctx context.Context, events *data.Events) ([]*model.Event, error) {
 	if events == nil {
 		return nil, errors.New("Found nothing")
 	}

--- a/app/rest/graph/data.go
+++ b/app/rest/graph/data.go
@@ -43,7 +43,7 @@ func ginContextFromContext(ctx context.Context) (*gin.Context, error) {
 }
 
 // Converting block data to graphQL compatible data structure
-func getGraphQLCompatibleBlock(block *data.Block) (*model.Block, error) {
+func getGraphQLCompatibleBlock(ctx context.Context, block *data.Block) (*model.Block, error) {
 	if block == nil {
 		return nil, errors.New("Found nothing")
 	}
@@ -65,7 +65,7 @@ func getGraphQLCompatibleBlock(block *data.Block) (*model.Block, error) {
 }
 
 // Converting block array to graphQL compatible data structure
-func getGraphQLCompatibleBlocks(blocks *data.Blocks) ([]*model.Block, error) {
+func getGraphQLCompatibleBlocks(ctx context.Context, blocks *data.Blocks) ([]*model.Block, error) {
 	if blocks == nil {
 		return nil, errors.New("Found nothing")
 	}
@@ -77,7 +77,7 @@ func getGraphQLCompatibleBlocks(blocks *data.Blocks) ([]*model.Block, error) {
 	_blocks := make([]*model.Block, len(blocks.Blocks))
 
 	for k, v := range blocks.Blocks {
-		_v, _ := getGraphQLCompatibleBlock(v)
+		_v, _ := getGraphQLCompatibleBlock(ctx, v)
 		_blocks[k] = _v
 	}
 
@@ -85,7 +85,7 @@ func getGraphQLCompatibleBlocks(blocks *data.Blocks) ([]*model.Block, error) {
 }
 
 // Converting transaction data to graphQL compatible data structure
-func getGraphQLCompatibleTransaction(tx *data.Transaction) (*model.Transaction, error) {
+func getGraphQLCompatibleTransaction(ctx context.Context, tx *data.Transaction) (*model.Transaction, error) {
 	if tx == nil {
 		return nil, errors.New("Found nothing")
 	}
@@ -129,7 +129,7 @@ func getGraphQLCompatibleTransaction(tx *data.Transaction) (*model.Transaction, 
 }
 
 // Converting transaction array to graphQL compatible data structure
-func getGraphQLCompatibleTransactions(tx *data.Transactions) ([]*model.Transaction, error) {
+func getGraphQLCompatibleTransactions(ctx context.Context, tx *data.Transactions) ([]*model.Transaction, error) {
 	if tx == nil {
 		return nil, errors.New("Found nothing")
 	}
@@ -141,7 +141,7 @@ func getGraphQLCompatibleTransactions(tx *data.Transactions) ([]*model.Transacti
 	_tx := make([]*model.Transaction, len(tx.Transactions))
 
 	for k, v := range tx.Transactions {
-		_v, _ := getGraphQLCompatibleTransaction(v)
+		_v, _ := getGraphQLCompatibleTransaction(ctx, v)
 		_tx[k] = _v
 	}
 
@@ -149,7 +149,7 @@ func getGraphQLCompatibleTransactions(tx *data.Transactions) ([]*model.Transacti
 }
 
 // Converting event data to graphQL compatible data structure
-func getGraphQLCompatibleEvent(event *data.Event) (*model.Event, error) {
+func getGraphQLCompatibleEvent(ctx context.Context, event *data.Event) (*model.Event, error) {
 	if event == nil {
 		return nil, errors.New("Found nothing")
 	}
@@ -170,7 +170,7 @@ func getGraphQLCompatibleEvent(event *data.Event) (*model.Event, error) {
 }
 
 // Converting event array to graphQL compatible data structure
-func getGraphQLCompatibleEvents(events *data.Events) ([]*model.Event, error) {
+func getGraphQLCompatibleEvents(ctx context.Context, events *data.Events) ([]*model.Event, error) {
 	if events == nil {
 		return nil, errors.New("Found nothing")
 	}
@@ -182,7 +182,7 @@ func getGraphQLCompatibleEvents(events *data.Events) ([]*model.Event, error) {
 	_events := make([]*model.Event, len(events.Events))
 
 	for k, v := range events.Events {
-		_v, _ := getGraphQLCompatibleEvent(v)
+		_v, _ := getGraphQLCompatibleEvent(ctx, v)
 		_events[k] = _v
 	}
 

--- a/app/rest/graph/data.go
+++ b/app/rest/graph/data.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/gin-gonic/gin"
 	"github.com/itzmeanjan/ette/app/data"
 	"github.com/itzmeanjan/ette/app/rest/graph/model"
 	"github.com/lib/pq"
@@ -20,6 +22,24 @@ var db *gorm.DB
 // so that it can be used for handling database queries for resolving graphQL queries
 func GetDatabaseConnection(conn *gorm.DB) {
 	db = conn
+}
+
+// Attempting to recover router context i.e. which holds client `APIKey` in request header,
+// in graphql handler context, so that we can do some accounting job
+func ginContextFromContext(ctx context.Context) (*gin.Context, error) {
+
+	ginContext := ctx.Value("RouterContextInGraphQL")
+	if ginContext == nil {
+		return nil, errors.New("Failed to retrieve router context")
+	}
+
+	gc, ok := ginContext.(*gin.Context)
+	if !ok {
+		return nil, errors.New("Type assert of router context failed")
+	}
+
+	return gc, nil
+
 }
 
 // Converting block data to graphQL compatible data structure

--- a/app/rest/graph/data.go
+++ b/app/rest/graph/data.go
@@ -26,7 +26,7 @@ func GetDatabaseConnection(conn *gorm.DB) {
 
 // Attempting to recover router context i.e. which holds client `APIKey` in request header,
 // in graphql handler context, so that we can do some accounting job
-func ginContextFromContext(ctx context.Context) (*gin.Context, error) {
+func routerContextFromGraphQLContext(ctx context.Context) (*gin.Context, error) {
 
 	ginContext := ctx.Value("RouterContextInGraphQL")
 	if ginContext == nil {
@@ -39,6 +39,20 @@ func ginContextFromContext(ctx context.Context) (*gin.Context, error) {
 	}
 
 	return gc, nil
+
+}
+
+// Attempts to extract out `APIKey` used passed along
+// with request, in graphql handler function, to be used for
+// doing some book keeping work
+func getAPIKey(ctx context.Context) string {
+
+	routerCtx, err := routerContextFromGraphQLContext(ctx)
+	if err != nil {
+		return ""
+	}
+
+	return routerCtx.GetHeader("APIKey")
 
 }
 

--- a/app/rest/graph/schema.resolvers.go
+++ b/app/rest/graph/schema.resolvers.go
@@ -21,7 +21,7 @@ func (r *queryResolver) BlockByHash(ctx context.Context, hash string) (*model.Bl
 		return nil, errors.New("Bad Block Hash")
 	}
 
-	return getGraphQLCompatibleBlock(ctx, _db.GetBlockByHash(db, common.HexToHash(hash)))
+	return getGraphQLCompatibleBlock(ctx, _db.GetBlockByHash(db, common.HexToHash(hash)), true)
 }
 
 func (r *queryResolver) BlockByNumber(ctx context.Context, number string) (*model.Block, error) {
@@ -30,7 +30,7 @@ func (r *queryResolver) BlockByNumber(ctx context.Context, number string) (*mode
 		return nil, errors.New("Bad Block Number")
 	}
 
-	return getGraphQLCompatibleBlock(ctx, _db.GetBlockByNumber(db, _number))
+	return getGraphQLCompatibleBlock(ctx, _db.GetBlockByNumber(db, _number), true)
 }
 
 func (r *queryResolver) BlocksByNumberRange(ctx context.Context, from string, to string) ([]*model.Block, error) {
@@ -73,7 +73,7 @@ func (r *queryResolver) Transaction(ctx context.Context, hash string) (*model.Tr
 		return nil, errors.New("Bad Transaction Hash")
 	}
 
-	return getGraphQLCompatibleTransaction(ctx, _db.GetTransactionByHash(db, common.HexToHash(hash)))
+	return getGraphQLCompatibleTransaction(ctx, _db.GetTransactionByHash(db, common.HexToHash(hash)), true)
 }
 
 func (r *queryResolver) TransactionsFromAccountByNumberRange(ctx context.Context, account string, from string, to string) ([]*model.Transaction, error) {
@@ -198,7 +198,7 @@ func (r *queryResolver) TransactionFromAccountWithNonce(ctx context.Context, acc
 		return nil, errors.New("Bad Account Nonce")
 	}
 
-	return getGraphQLCompatibleTransaction(ctx, _db.GetTransactionFromAccountWithNonce(db, common.HexToAddress(account), _nonce))
+	return getGraphQLCompatibleTransaction(ctx, _db.GetTransactionFromAccountWithNonce(db, common.HexToAddress(account), _nonce), true)
 }
 
 func (r *queryResolver) EventsFromContractByNumberRange(ctx context.Context, contract string, from string, to string) ([]*model.Event, error) {
@@ -292,7 +292,7 @@ func (r *queryResolver) EventByBlockHashAndLogIndex(ctx context.Context, hash st
 		return nil, errors.New("Bad Log Index")
 	}
 
-	return getGraphQLCompatibleEvent(ctx, _db.GetEventByBlockHashAndLogIndex(db, common.HexToHash(hash), uint(_index)))
+	return getGraphQLCompatibleEvent(ctx, _db.GetEventByBlockHashAndLogIndex(db, common.HexToHash(hash), uint(_index)), true)
 
 }
 
@@ -308,7 +308,7 @@ func (r *queryResolver) EventByBlockNumberAndLogIndex(ctx context.Context, numbe
 		return nil, errors.New("Bad Log Index")
 	}
 
-	return getGraphQLCompatibleEvent(ctx, _db.GetEventByBlockNumberAndLogIndex(db, _number, uint(_index)))
+	return getGraphQLCompatibleEvent(ctx, _db.GetEventByBlockNumberAndLogIndex(db, _number, uint(_index)), true)
 
 }
 

--- a/app/rest/graph/schema.resolvers.go
+++ b/app/rest/graph/schema.resolvers.go
@@ -21,7 +21,7 @@ func (r *queryResolver) BlockByHash(ctx context.Context, hash string) (*model.Bl
 		return nil, errors.New("Bad Block Hash")
 	}
 
-	return getGraphQLCompatibleBlock(_db.GetBlockByHash(db, common.HexToHash(hash)))
+	return getGraphQLCompatibleBlock(ctx, _db.GetBlockByHash(db, common.HexToHash(hash)))
 }
 
 func (r *queryResolver) BlockByNumber(ctx context.Context, number string) (*model.Block, error) {
@@ -30,7 +30,7 @@ func (r *queryResolver) BlockByNumber(ctx context.Context, number string) (*mode
 		return nil, errors.New("Bad Block Number")
 	}
 
-	return getGraphQLCompatibleBlock(_db.GetBlockByNumber(db, _number))
+	return getGraphQLCompatibleBlock(ctx, _db.GetBlockByNumber(db, _number))
 }
 
 func (r *queryResolver) BlocksByNumberRange(ctx context.Context, from string, to string) ([]*model.Block, error) {
@@ -39,7 +39,7 @@ func (r *queryResolver) BlocksByNumberRange(ctx context.Context, from string, to
 		return nil, errors.New("Bad Block Number Range")
 	}
 
-	return getGraphQLCompatibleBlocks(_db.GetBlocksByNumberRange(db, _from, _to))
+	return getGraphQLCompatibleBlocks(ctx, _db.GetBlocksByNumberRange(db, _from, _to))
 }
 
 func (r *queryResolver) BlocksByTimeRange(ctx context.Context, from string, to string) ([]*model.Block, error) {
@@ -48,7 +48,7 @@ func (r *queryResolver) BlocksByTimeRange(ctx context.Context, from string, to s
 		return nil, errors.New("Bad Block Timestamp Range")
 	}
 
-	return getGraphQLCompatibleBlocks(_db.GetBlocksByTimeRange(db, _from, _to))
+	return getGraphQLCompatibleBlocks(ctx, _db.GetBlocksByTimeRange(db, _from, _to))
 }
 
 func (r *queryResolver) TransactionsByBlockHash(ctx context.Context, hash string) ([]*model.Transaction, error) {
@@ -56,7 +56,7 @@ func (r *queryResolver) TransactionsByBlockHash(ctx context.Context, hash string
 		return nil, errors.New("Bad Block Hash")
 	}
 
-	return getGraphQLCompatibleTransactions(_db.GetTransactionsByBlockHash(db, common.HexToHash(hash)))
+	return getGraphQLCompatibleTransactions(ctx, _db.GetTransactionsByBlockHash(db, common.HexToHash(hash)))
 }
 
 func (r *queryResolver) TransactionsByBlockNumber(ctx context.Context, number string) ([]*model.Transaction, error) {
@@ -65,7 +65,7 @@ func (r *queryResolver) TransactionsByBlockNumber(ctx context.Context, number st
 		return nil, errors.New("Bad Block Number")
 	}
 
-	return getGraphQLCompatibleTransactions(_db.GetTransactionsByBlockNumber(db, _number))
+	return getGraphQLCompatibleTransactions(ctx, _db.GetTransactionsByBlockNumber(db, _number))
 }
 
 func (r *queryResolver) Transaction(ctx context.Context, hash string) (*model.Transaction, error) {
@@ -73,7 +73,7 @@ func (r *queryResolver) Transaction(ctx context.Context, hash string) (*model.Tr
 		return nil, errors.New("Bad Transaction Hash")
 	}
 
-	return getGraphQLCompatibleTransaction(_db.GetTransactionByHash(db, common.HexToHash(hash)))
+	return getGraphQLCompatibleTransaction(ctx, _db.GetTransactionByHash(db, common.HexToHash(hash)))
 }
 
 func (r *queryResolver) TransactionsFromAccountByNumberRange(ctx context.Context, account string, from string, to string) ([]*model.Transaction, error) {
@@ -86,7 +86,7 @@ func (r *queryResolver) TransactionsFromAccountByNumberRange(ctx context.Context
 		return nil, errors.New("Bad Block Number Range")
 	}
 
-	return getGraphQLCompatibleTransactions(_db.GetTransactionsFromAccountByBlockNumberRange(db, common.HexToAddress(account), _from, _to))
+	return getGraphQLCompatibleTransactions(ctx, _db.GetTransactionsFromAccountByBlockNumberRange(db, common.HexToAddress(account), _from, _to))
 }
 
 func (r *queryResolver) TransactionsFromAccountByTimeRange(ctx context.Context, account string, from string, to string) ([]*model.Transaction, error) {
@@ -99,7 +99,7 @@ func (r *queryResolver) TransactionsFromAccountByTimeRange(ctx context.Context, 
 		return nil, errors.New("Bad Block Timestamp Range")
 	}
 
-	return getGraphQLCompatibleTransactions(_db.GetTransactionsFromAccountByBlockTimeRange(db, common.HexToAddress(account), _from, _to))
+	return getGraphQLCompatibleTransactions(ctx, _db.GetTransactionsFromAccountByBlockTimeRange(db, common.HexToAddress(account), _from, _to))
 }
 
 func (r *queryResolver) TransactionsToAccountByNumberRange(ctx context.Context, account string, from string, to string) ([]*model.Transaction, error) {
@@ -112,7 +112,7 @@ func (r *queryResolver) TransactionsToAccountByNumberRange(ctx context.Context, 
 		return nil, errors.New("Bad Block Number Range")
 	}
 
-	return getGraphQLCompatibleTransactions(_db.GetTransactionsToAccountByBlockNumberRange(db, common.HexToAddress(account), _from, _to))
+	return getGraphQLCompatibleTransactions(ctx, _db.GetTransactionsToAccountByBlockNumberRange(db, common.HexToAddress(account), _from, _to))
 }
 
 func (r *queryResolver) TransactionsToAccountByTimeRange(ctx context.Context, account string, from string, to string) ([]*model.Transaction, error) {
@@ -125,7 +125,7 @@ func (r *queryResolver) TransactionsToAccountByTimeRange(ctx context.Context, ac
 		return nil, errors.New("Bad Block Timestamp Range")
 	}
 
-	return getGraphQLCompatibleTransactions(_db.GetTransactionsToAccountByBlockTimeRange(db, common.HexToAddress(account), _from, _to))
+	return getGraphQLCompatibleTransactions(ctx, _db.GetTransactionsToAccountByBlockTimeRange(db, common.HexToAddress(account), _from, _to))
 }
 
 func (r *queryResolver) TransactionsBetweenAccountsByNumberRange(ctx context.Context, fromAccount string, toAccount string, from string, to string) ([]*model.Transaction, error) {
@@ -142,7 +142,7 @@ func (r *queryResolver) TransactionsBetweenAccountsByNumberRange(ctx context.Con
 		return nil, errors.New("Bad Block Number Range")
 	}
 
-	return getGraphQLCompatibleTransactions(_db.GetTransactionsBetweenAccountsByBlockNumberRange(db, common.HexToAddress(fromAccount), common.HexToAddress(toAccount), _from, _to))
+	return getGraphQLCompatibleTransactions(ctx, _db.GetTransactionsBetweenAccountsByBlockNumberRange(db, common.HexToAddress(fromAccount), common.HexToAddress(toAccount), _from, _to))
 }
 
 func (r *queryResolver) TransactionsBetweenAccountsByTimeRange(ctx context.Context, fromAccount string, toAccount string, from string, to string) ([]*model.Transaction, error) {
@@ -159,7 +159,7 @@ func (r *queryResolver) TransactionsBetweenAccountsByTimeRange(ctx context.Conte
 		return nil, errors.New("Bad Block Timestamp Range")
 	}
 
-	return getGraphQLCompatibleTransactions(_db.GetTransactionsBetweenAccountsByBlockTimeRange(db, common.HexToAddress(fromAccount), common.HexToAddress(toAccount), _from, _to))
+	return getGraphQLCompatibleTransactions(ctx, _db.GetTransactionsBetweenAccountsByBlockTimeRange(db, common.HexToAddress(fromAccount), common.HexToAddress(toAccount), _from, _to))
 }
 
 func (r *queryResolver) ContractsCreatedFromAccountByNumberRange(ctx context.Context, account string, from string, to string) ([]*model.Transaction, error) {
@@ -172,7 +172,7 @@ func (r *queryResolver) ContractsCreatedFromAccountByNumberRange(ctx context.Con
 		return nil, errors.New("Bad Block Number Range")
 	}
 
-	return getGraphQLCompatibleTransactions(_db.GetContractCreationTransactionsFromAccountByBlockNumberRange(db, common.HexToAddress(account), _from, _to))
+	return getGraphQLCompatibleTransactions(ctx, _db.GetContractCreationTransactionsFromAccountByBlockNumberRange(db, common.HexToAddress(account), _from, _to))
 }
 
 func (r *queryResolver) ContractsCreatedFromAccountByTimeRange(ctx context.Context, account string, from string, to string) ([]*model.Transaction, error) {
@@ -185,7 +185,7 @@ func (r *queryResolver) ContractsCreatedFromAccountByTimeRange(ctx context.Conte
 		return nil, errors.New("Bad Block Timestamp Range")
 	}
 
-	return getGraphQLCompatibleTransactions(_db.GetContractCreationTransactionsFromAccountByBlockTimeRange(db, common.HexToAddress(account), _from, _to))
+	return getGraphQLCompatibleTransactions(ctx, _db.GetContractCreationTransactionsFromAccountByBlockTimeRange(db, common.HexToAddress(account), _from, _to))
 }
 
 func (r *queryResolver) TransactionFromAccountWithNonce(ctx context.Context, account string, nonce string) (*model.Transaction, error) {
@@ -198,7 +198,7 @@ func (r *queryResolver) TransactionFromAccountWithNonce(ctx context.Context, acc
 		return nil, errors.New("Bad Account Nonce")
 	}
 
-	return getGraphQLCompatibleTransaction(_db.GetTransactionFromAccountWithNonce(db, common.HexToAddress(account), _nonce))
+	return getGraphQLCompatibleTransaction(ctx, _db.GetTransactionFromAccountWithNonce(db, common.HexToAddress(account), _nonce))
 }
 
 func (r *queryResolver) EventsFromContractByNumberRange(ctx context.Context, contract string, from string, to string) ([]*model.Event, error) {
@@ -211,7 +211,7 @@ func (r *queryResolver) EventsFromContractByNumberRange(ctx context.Context, con
 		return nil, errors.New("Bad Block Number Range")
 	}
 
-	return getGraphQLCompatibleEvents(_db.GetEventsFromContractByBlockNumberRange(db, common.HexToAddress(contract), _from, _to))
+	return getGraphQLCompatibleEvents(ctx, _db.GetEventsFromContractByBlockNumberRange(db, common.HexToAddress(contract), _from, _to))
 }
 
 func (r *queryResolver) EventsFromContractByTimeRange(ctx context.Context, contract string, from string, to string) ([]*model.Event, error) {
@@ -224,7 +224,7 @@ func (r *queryResolver) EventsFromContractByTimeRange(ctx context.Context, contr
 		return nil, errors.New("Bad Block Timestamp Range")
 	}
 
-	return getGraphQLCompatibleEvents(_db.GetEventsFromContractByBlockTimeRange(db, common.HexToAddress(contract), _from, _to))
+	return getGraphQLCompatibleEvents(ctx, _db.GetEventsFromContractByBlockTimeRange(db, common.HexToAddress(contract), _from, _to))
 }
 
 func (r *queryResolver) EventsByBlockHash(ctx context.Context, hash string) ([]*model.Event, error) {
@@ -232,7 +232,7 @@ func (r *queryResolver) EventsByBlockHash(ctx context.Context, hash string) ([]*
 		return nil, errors.New("Bad Block Hash")
 	}
 
-	return getGraphQLCompatibleEvents(_db.GetEventsByBlockHash(db, common.HexToHash(hash)))
+	return getGraphQLCompatibleEvents(ctx, _db.GetEventsByBlockHash(db, common.HexToHash(hash)))
 }
 
 func (r *queryResolver) EventsByTxHash(ctx context.Context, hash string) ([]*model.Event, error) {
@@ -240,7 +240,7 @@ func (r *queryResolver) EventsByTxHash(ctx context.Context, hash string) ([]*mod
 		return nil, errors.New("Bad Transaction Hash")
 	}
 
-	return getGraphQLCompatibleEvents(_db.GetEventsByTransactionHash(db, common.HexToHash(hash)))
+	return getGraphQLCompatibleEvents(ctx, _db.GetEventsByTransactionHash(db, common.HexToHash(hash)))
 }
 
 func (r *queryResolver) EventsFromContractWithTopicsByNumberRange(ctx context.Context, contract string, from string, to string, topics []string) ([]*model.Event, error) {
@@ -253,7 +253,7 @@ func (r *queryResolver) EventsFromContractWithTopicsByNumberRange(ctx context.Co
 		return nil, errors.New("Bad Block Number Range")
 	}
 
-	return getGraphQLCompatibleEvents(_db.GetEventsFromContractWithTopicsByBlockNumberRange(db, common.HexToAddress(contract), _from, _to, getTopics(topics...)...))
+	return getGraphQLCompatibleEvents(ctx, _db.GetEventsFromContractWithTopicsByBlockNumberRange(db, common.HexToAddress(contract), _from, _to, getTopics(topics...)...))
 }
 
 func (r *queryResolver) EventsFromContractWithTopicsByTimeRange(ctx context.Context, contract string, from string, to string, topics []string) ([]*model.Event, error) {
@@ -266,7 +266,7 @@ func (r *queryResolver) EventsFromContractWithTopicsByTimeRange(ctx context.Cont
 		return nil, errors.New("Bad Block Timestamp Range")
 	}
 
-	return getGraphQLCompatibleEvents(_db.GetEventsFromContractWithTopicsByBlockTimeRange(db, common.HexToAddress(contract), _from, _to, getTopics(topics...)...))
+	return getGraphQLCompatibleEvents(ctx, _db.GetEventsFromContractWithTopicsByBlockTimeRange(db, common.HexToAddress(contract), _from, _to, getTopics(topics...)...))
 }
 
 func (r *queryResolver) LastXEventsFromContract(ctx context.Context, contract string, x int) ([]*model.Event, error) {
@@ -278,7 +278,7 @@ func (r *queryResolver) LastXEventsFromContract(ctx context.Context, contract st
 		return nil, errors.New("Too Many Events Requested")
 	}
 
-	return getGraphQLCompatibleEvents(_db.GetLastXEventsFromContract(db, common.HexToAddress(contract), x))
+	return getGraphQLCompatibleEvents(ctx, _db.GetLastXEventsFromContract(db, common.HexToAddress(contract), x))
 }
 
 func (r *queryResolver) EventByBlockHashAndLogIndex(ctx context.Context, hash string, index string) (*model.Event, error) {
@@ -292,7 +292,7 @@ func (r *queryResolver) EventByBlockHashAndLogIndex(ctx context.Context, hash st
 		return nil, errors.New("Bad Log Index")
 	}
 
-	return getGraphQLCompatibleEvent(_db.GetEventByBlockHashAndLogIndex(db, common.HexToHash(hash), uint(_index)))
+	return getGraphQLCompatibleEvent(ctx, _db.GetEventByBlockHashAndLogIndex(db, common.HexToHash(hash), uint(_index)))
 
 }
 
@@ -308,7 +308,7 @@ func (r *queryResolver) EventByBlockNumberAndLogIndex(ctx context.Context, numbe
 		return nil, errors.New("Bad Log Index")
 	}
 
-	return getGraphQLCompatibleEvent(_db.GetEventByBlockNumberAndLogIndex(db, _number, uint(_index)))
+	return getGraphQLCompatibleEvent(ctx, _db.GetEventByBlockNumberAndLogIndex(db, _number, uint(_index)))
 
 }
 


### PR DESCRIPTION
## Changes

- All requests being made to `/v1/graphql` to be scanned by rate limiter, using `APIKey` provided
- When successfully data can be delivered in response, only then book keeping to be done
- 👆 to be used while deciding whether request can be entertained or not, when next time request from same client to be received
