### PR TITLE
Improve missing block finder & retry queue manager

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -73,9 +73,9 @@ func bootstrap(configFile, subscriptionPlansFile string) (*d.BlockChainNodeConne
 func Run(configFile, subscriptionPlansFile string) {
 	_connection, _redisClient, _db, _status := bootstrap(configFile, subscriptionPlansFile)
 	_redisInfo := d.RedisInfo{
-		Client:                     _redisClient,
-		BlockRetryQueueName:        "blocks_in_retry_queue",
-		UnfinalizedBlocksQueueName: "unfinalized_blocks",
+		Client:                 _redisClient,
+		BlockRetryQueue:        "blocks_in_retry_queue",
+		UnfinalizedBlocksQueue: "unfinalized_blocks",
 	}
 
 	// Attempting to listen to Ctrl+C signal

--- a/app/app.go
+++ b/app/app.go
@@ -75,6 +75,7 @@ func Run(configFile, subscriptionPlansFile string) {
 	_redisInfo := d.RedisInfo{
 		Client:                 _redisClient,
 		BlockRetryQueue:        "blocks_in_retry_queue",
+		BlockRetryCountTable:   "attempt_count_tracker_table",
 		UnfinalizedBlocksQueue: "unfinalized_blocks",
 	}
 

--- a/app/block/fetch.go
+++ b/app/block/fetch.go
@@ -53,7 +53,14 @@ func FetchBlockByNumber(client *ethclient.Client, number uint64, _db *gorm.DB, r
 		return
 	}
 
-	ProcessBlockContent(client, block, _db, redis, publishable, _status, startingAt)
+	// If attempt to process block by number went successful
+	// we can consider removing this block number's entry from
+	// attempt count tracker table
+	if ProcessBlockContent(client, block, _db, redis, publishable, _status, startingAt) {
+
+		RemoveBlockFromAttemptCountTrackerTable(redis, fmt.Sprintf("%d", number))
+
+	}
 
 }
 

--- a/app/block/retry.go
+++ b/app/block/retry.go
@@ -37,7 +37,7 @@ func RetryQueueManager(client *ethclient.Client, _db *gorm.DB, redis *data.Redis
 		sleep()
 
 		// Popping oldest element from Redis queue
-		blockNumber, err := redis.Client.LPop(context.Background(), redis.BlockRetryQueueName).Result()
+		blockNumber, err := redis.Client.LPop(context.Background(), redis.BlockRetryQueue).Result()
 		if err != nil {
 			continue
 		}
@@ -82,7 +82,7 @@ func PushBlockIntoRetryQueue(redis *data.RedisInfo, blockNumber string) {
 	// Checking presence first & then deciding whether to add it or not
 	if !CheckBlockInRetryQueue(redis, blockNumber) {
 
-		if _, err := redis.Client.RPush(context.Background(), redis.BlockRetryQueueName, blockNumber).Result(); err != nil {
+		if _, err := redis.Client.RPush(context.Background(), redis.BlockRetryQueue, blockNumber).Result(); err != nil {
 			log.Print(color.Red.Sprintf("[!] Failed to push block %s into retry queue : %s", blockNumber, err.Error()))
 		}
 
@@ -97,7 +97,7 @@ func PushBlockIntoRetryQueue(redis *data.RedisInfo, blockNumber string) {
 // Note: this feature of checking index of value in redis queue,
 // was added in Redis v6.0.6 : https://redis.io/commands/lpos
 func CheckBlockInRetryQueue(redis *data.RedisInfo, blockNumber string) bool {
-	if _, err := redis.Client.LPos(context.Background(), redis.BlockRetryQueueName, blockNumber, _redis.LPosArgs{}).Result(); err != nil {
+	if _, err := redis.Client.LPos(context.Background(), redis.BlockRetryQueue, blockNumber, _redis.LPosArgs{}).Result(); err != nil {
 		return false
 	}
 
@@ -107,7 +107,7 @@ func CheckBlockInRetryQueue(redis *data.RedisInfo, blockNumber string) bool {
 // GetRetryQueueLength - Returns redis backed retry queue length
 func GetRetryQueueLength(redis *data.RedisInfo) int64 {
 
-	blockCount, err := redis.Client.LLen(context.Background(), redis.BlockRetryQueueName).Result()
+	blockCount, err := redis.Client.LLen(context.Background(), redis.BlockRetryQueue).Result()
 	if err != nil {
 		log.Printf(color.Red.Sprintf("[!] Failed to determine retry queue length : %s", err.Error()))
 	}

--- a/app/block/retry.go
+++ b/app/block/retry.go
@@ -115,6 +115,24 @@ func CheckBlockInAttemptCounterTable(redis *data.RedisInfo, blockNumber string) 
 
 }
 
+// GetAttemptCountFromTable - Returns current attempt counter from table
+// for given block number
+func GetAttemptCountFromTable(redis *data.RedisInfo, blockNumber string) uint64 {
+
+	count, err := redis.Client.HGet(context.Background(), redis.BlockRetryCountTable, blockNumber).Result()
+	if err != nil {
+		return 0
+	}
+
+	parsedCount, err := strconv.ParseUint(count, 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	return parsedCount
+
+}
+
 // RemoveBlockFromAttemptCountTrackerTable - Attempt to delete block number's
 // associated attempt count, given it already exists in table
 //

--- a/app/block/syncer.go
+++ b/app/block/syncer.go
@@ -20,15 +20,18 @@ import (
 // FindMissingBlocksInRange - Given ascending ordered block numbers read from DB
 // attempts to find out which numbers are missing in [from, to] range
 // where both ends are inclusive
-func FindMissingBlocksInRange(found []uint64, shouldBeFrom uint64, shouldBeTo uint64) []uint64 {
+func FindMissingBlocksInRange(found []uint64, from uint64, to uint64) []uint64 {
 
-	absent := make([]uint64, 0)
+	// creating slice with backing array of larger size
+	// to avoid potential memory allocation during iteration
+	// over loop
+	absent := make([]uint64, 0, to-from+1)
 
-	for b := shouldBeFrom; b <= shouldBeTo; b++ {
+	for b := from; b <= to; b++ {
 
-		_i := sort.Search(len(found), func(j int) bool { return found[j] >= b })
+		idx := sort.Search(len(found), func(j int) bool { return found[j] >= b })
 
-		if !(_i < len(found) && found[_i] == b) {
+		if !(idx < len(found) && found[idx] == b) {
 			absent = append(absent, b)
 		}
 

--- a/app/block/unfinalized_blocks.go
+++ b/app/block/unfinalized_blocks.go
@@ -2,6 +2,7 @@ package block
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strconv"
 
@@ -71,6 +72,15 @@ func PushBlockIntoUnfinalizedQueue(redis *data.RedisInfo, blockNumber string) {
 		}
 
 	}
+}
+
+// MoveUnfinalizedOldestBlockToEnd - Attempts to pop oldest block ( i.e. left most block )
+// from unfinalized queue & pushes it back to end of queue, so that other blocks waiting after
+// this one can get be attempted to be processed by workers
+func MoveUnfinalizedOldestBlockToEnd(redis *data.RedisInfo) {
+
+	PushBlockIntoUnfinalizedQueue(redis, fmt.Sprintf("%d", PopOldestBlockFromUnfinalizedQueue(redis)))
+
 }
 
 // CheckBlockInUnfinalizedQueue - Checks whether block number is already added in

--- a/app/block/unfinalized_blocks.go
+++ b/app/block/unfinalized_blocks.go
@@ -77,6 +77,8 @@ func PushBlockIntoUnfinalizedQueue(redis *data.RedisInfo, blockNumber string) {
 // MoveUnfinalizedOldestBlockToEnd - Attempts to pop oldest block ( i.e. left most block )
 // from unfinalized queue & pushes it back to end of queue, so that other blocks waiting after
 // this one can get be attempted to be processed by workers
+//
+// @note This can be improved using `LMOVE` command of Redis ( >= 6.2.0 )
 func MoveUnfinalizedOldestBlockToEnd(redis *data.RedisInfo) {
 
 	PushBlockIntoUnfinalizedQueue(redis, fmt.Sprintf("%d", PopOldestBlockFromUnfinalizedQueue(redis)))

--- a/app/block/unfinalized_blocks.go
+++ b/app/block/unfinalized_blocks.go
@@ -14,7 +14,7 @@ import (
 // i.e. element at 0th index
 func GetOldestBlockFromUnfinalizedQueue(redis *data.RedisInfo) string {
 
-	blockNumber, err := redis.Client.LIndex(context.Background(), redis.UnfinalizedBlocksQueueName, 0).Result()
+	blockNumber, err := redis.Client.LIndex(context.Background(), redis.UnfinalizedBlocksQueue, 0).Result()
 	if err != nil {
 		return ""
 	}
@@ -45,7 +45,7 @@ func CheckIfOldestBlockIsConfirmed(redis *data.RedisInfo, status *data.StatusHol
 // queue, which can be processed now
 func PopOldestBlockFromUnfinalizedQueue(redis *data.RedisInfo) uint64 {
 
-	blockNumber, err := redis.Client.LPop(context.Background(), redis.UnfinalizedBlocksQueueName).Result()
+	blockNumber, err := redis.Client.LPop(context.Background(), redis.UnfinalizedBlocksQueue).Result()
 	if err != nil {
 		return 0
 	}
@@ -66,7 +66,7 @@ func PushBlockIntoUnfinalizedQueue(redis *data.RedisInfo, blockNumber string) {
 	// Checking presence first & then deciding whether to add it or not
 	if !CheckBlockInUnfinalizedQueue(redis, blockNumber) {
 
-		if _, err := redis.Client.RPush(context.Background(), redis.UnfinalizedBlocksQueueName, blockNumber).Result(); err != nil {
+		if _, err := redis.Client.RPush(context.Background(), redis.UnfinalizedBlocksQueue, blockNumber).Result(); err != nil {
 			log.Print(color.Red.Sprintf("[!] Failed to push block %s into non-final block queue : %s", blockNumber, err.Error()))
 		}
 
@@ -81,7 +81,7 @@ func PushBlockIntoUnfinalizedQueue(redis *data.RedisInfo, blockNumber string) {
 // Note: this feature of checking index of value in redis queue,
 // was added in Redis v6.0.6 : https://redis.io/commands/lpos
 func CheckBlockInUnfinalizedQueue(redis *data.RedisInfo, blockNumber string) bool {
-	if _, err := redis.Client.LPos(context.Background(), redis.UnfinalizedBlocksQueueName, blockNumber, _redis.LPosArgs{}).Result(); err != nil {
+	if _, err := redis.Client.LPos(context.Background(), redis.UnfinalizedBlocksQueue, blockNumber, _redis.LPosArgs{}).Result(); err != nil {
 		return false
 	}
 
@@ -91,7 +91,7 @@ func CheckBlockInUnfinalizedQueue(redis *data.RedisInfo, blockNumber string) boo
 // GetUnfinalizedQueueLength - Returns redis backed unfinalized block number queue length
 func GetUnfinalizedQueueLength(redis *data.RedisInfo) int64 {
 
-	blockCount, err := redis.Client.LLen(context.Background(), redis.UnfinalizedBlocksQueueName).Result()
+	blockCount, err := redis.Client.LLen(context.Background(), redis.UnfinalizedBlocksQueue).Result()
 	if err != nil {
 		log.Printf(color.Red.Sprintf("[!] Failed to determine non-final block queue length : %s", err.Error()))
 	}

--- a/app/data/data.go
+++ b/app/data/data.go
@@ -135,9 +135,9 @@ func (s *StatusHolder) SetLatestBlockNumber(num uint64) {
 // RedisInfo - Holds redis related information in this struct, to be used
 // when passing to functions as argument
 type RedisInfo struct {
-	Client                     *redis.Client // using this object `ette` will talk to Redis
-	BlockRetryQueueName        string        // retry queue name, for storing block numbers
-	UnfinalizedBlocksQueueName string        // stores unfinalized block numbers, processes
+	Client                 *redis.Client // using this object `ette` will talk to Redis
+	BlockRetryQueue        string        // retry queue name, for storing block numbers
+	UnfinalizedBlocksQueue string        // stores unfinalized block numbers, processes
 	// them later after reaching finality ( as set by deployer of `ette` )
 }
 

--- a/app/data/data.go
+++ b/app/data/data.go
@@ -135,9 +135,11 @@ func (s *StatusHolder) SetLatestBlockNumber(num uint64) {
 // RedisInfo - Holds redis related information in this struct, to be used
 // when passing to functions as argument
 type RedisInfo struct {
-	Client                 *redis.Client // using this object `ette` will talk to Redis
-	BlockRetryQueue        string        // retry queue name, for storing block numbers
-	UnfinalizedBlocksQueue string        // stores unfinalized block numbers, processes
+	Client               *redis.Client // using this object `ette` will talk to Redis
+	BlockRetryQueue      string        // retry queue name, for storing block numbers
+	BlockRetryCountTable string        // keeping track of how many times this block was attempted
+	// to be processed in past, but went unsuccessful
+	UnfinalizedBlocksQueue string // stores unfinalized block numbers, processes
 	// them later after reaching finality ( as set by deployer of `ette` )
 }
 

--- a/app/db/query.go
+++ b/app/db/query.go
@@ -14,14 +14,14 @@ func GetAllBlockNumbersInRange(db *gorm.DB, from uint64, to uint64) []uint64 {
 	var blocks []uint64
 
 	if from < to {
-		if err := db.Model(&Blocks{}).Where("number >= ? and number <= ?", from, to).Select("number").Find(&blocks).Error; err != nil {
+		if err := db.Model(&Blocks{}).Where("number >= ? and number <= ?", from, to).Order("number asc").Select("number").Find(&blocks).Error; err != nil {
 
 			log.Printf("[!] Failed to fetch block numbers by range : %s\n", err.Error())
 			return nil
 
 		}
 	} else {
-		if err := db.Model(&Blocks{}).Where("number >= ? and number <= ?", to, from).Select("number").Find(&blocks).Error; err != nil {
+		if err := db.Model(&Blocks{}).Where("number >= ? and number <= ?", to, from).Order("number asc").Select("number").Find(&blocks).Error; err != nil {
 
 			log.Printf("[!] Failed to fetch block numbers by range : %s\n", err.Error())
 			return nil

--- a/app/pubsub/subscription.go
+++ b/app/pubsub/subscription.go
@@ -97,12 +97,12 @@ func (s *SubscriptionRequest) DoesMatchWithPublishedEventData(event *data.Event)
 	// --- Matching specific topic signature provided by client
 	// application with received event data, published by
 	// redis pub-sub
-	matchTopicXInEvent := func(topic string, x int) bool {
+	matchTopicXInEvent := func(topic string, x uint8) bool {
 		// Not all topics will have 4 elements in topics array
 		//
 		// For those cases, if topic signature for that index is {"", "*"}
 		// provided by consumer, then we're safely going to say it's a match
-		if !(x < len(event.Topics)) {
+		if !(int(x) < len(event.Topics)) {
 			return topic == "" || topic == "*"
 		}
 
@@ -114,7 +114,7 @@ func (s *SubscriptionRequest) DoesMatchWithPublishedEventData(event *data.Event)
 			status = true
 		// match with specific `topic` signature
 		default:
-			status = topic == event.Topics[x]
+			status = CheckSimilarity(topic, event.Topics[x])
 		}
 
 		return status
@@ -135,7 +135,7 @@ func (s *SubscriptionRequest) DoesMatchWithPublishedEventData(event *data.Event)
 		status = matchTopicXInEvent(filters[1], 0) && matchTopicXInEvent(filters[2], 1) && matchTopicXInEvent(filters[3], 2) && matchTopicXInEvent(filters[4], 3)
 	// match with provided `contract` address
 	default:
-		if filters[0] == event.Origin {
+		if CheckSimilarity(filters[0], event.Origin) {
 			status = matchTopicXInEvent(filters[1], 0) && matchTopicXInEvent(filters[2], 1) && matchTopicXInEvent(filters[3], 2) && matchTopicXInEvent(filters[4], 3)
 		}
 	}
@@ -191,7 +191,7 @@ func (s *SubscriptionRequest) DoesMatchWithPublishedTransactionData(tx *data.Tra
 			status = true
 		// match with specific `to` address
 		default:
-			status = to == tx.To
+			status = CheckSimilarity(to, tx.To)
 		}
 
 		return status
@@ -211,7 +211,7 @@ func (s *SubscriptionRequest) DoesMatchWithPublishedTransactionData(tx *data.Tra
 		status = matchToFieldInTx(filters[1])
 	// match with provided `from` address
 	default:
-		if filters[0] == tx.From {
+		if CheckSimilarity(filters[0], tx.From) {
 			status = matchToFieldInTx(filters[1])
 		}
 	}

--- a/app/pubsub/subscription.go
+++ b/app/pubsub/subscription.go
@@ -1,6 +1,7 @@
 package pubsub
 
 import (
+	"fmt"
 	"log"
 	"regexp"
 	"strings"
@@ -154,6 +155,20 @@ func (s *SubscriptionRequest) GetTransactionFilters() []string {
 
 	matches := pattern.FindStringSubmatch(s.Name)
 	return []string{matches[4], matches[6]}
+}
+
+// CheckSimilarity - Performing case insensitive matching between two
+// strings
+func CheckSimilarity(first string, second string) bool {
+
+	reg, err := regexp.Compile(fmt.Sprintf("(?i)^(%s)$", first))
+	if err != nil {
+		log.Printf("[!] Failed to parse regex pattern : %s\n", err.Error())
+		return false
+	}
+
+	return reg.MatchString(second)
+
 }
 
 // DoesMatchWithPublishedTransactionData - All `transaction` topic listeners i.e. subscribers are

--- a/app/snapshot/write.go
+++ b/app/snapshot/write.go
@@ -58,6 +58,8 @@ func TakeSnapshot(db *gorm.DB, file string, start uint64, end uint64, count uint
 	go PutIntoSink(fd, count, data, done)
 
 	// attempting to fetch X blocks ( max ) at a time, by range
+	//
+	// @note This can be improved
 	var step uint64 = 10000
 
 	// stepping through blocks present in DB


### PR DESCRIPTION
## Changes

- Missing block finder **previously** used to query DB for all blocks
- **Now** it attempts to query blocks by range ( batch request ) & processes only missing ones
- Retry queue manager only attempts to process missing block for every 3rd request, for a certain block number
- 👆 potentially reduces #-of RPC calls being made to full node for block, which is probably still not available in node
- For implementing above one **Redis** backed hash table is being used & wrapped attempt count being stored there
