### PR TITLE
Conflicting Block Entry Resolution 

### DIFF
--- a/app/db/model.go
+++ b/app/db/model.go
@@ -31,8 +31,8 @@ type Blocks struct {
 	TransactionRootHash string       `gorm:"column:txroothash;type:char(66);not null"`
 	ReceiptRootHash     string       `gorm:"column:receiptroothash;type:char(66);not null"`
 	ExtraData           []byte       `gorm:"column:extradata;type:bytea"`
-	Transactions        Transactions `gorm:"foreignKey:blockhash"`
-	Events              Events       `gorm:"foreignKey:blockhash"`
+	Transactions        Transactions `gorm:"foreignKey:blockhash;constraint:OnDelete:CASCADE;"`
+	Events              Events       `gorm:"foreignKey:blockhash;constraint:OnDelete:CASCADE;"`
 }
 
 // TableName - Overriding default table name
@@ -73,7 +73,7 @@ type Transactions struct {
 	Nonce     uint64 `gorm:"column:nonce;type:bigint;not null;index"`
 	State     uint64 `gorm:"column:state;type:smallint;not null"`
 	BlockHash string `gorm:"column:blockhash;type:char(66);not null;index"`
-	Events    Events `gorm:"foreignKey:txhash"`
+	Events    Events `gorm:"foreignKey:txhash;constraint:OnDelete:CASCADE;"`
 }
 
 // TableName - Overriding default table name

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -36,7 +36,7 @@ create table transactions (
     nonce bigint not null,
     state smallint not null,
     blockhash char(66) not null,
-    foreign key (blockhash) references blocks(hash)
+    foreign key (blockhash) references blocks(hash) on delete cascade
 );
 
 create index on transactions(from);
@@ -53,8 +53,8 @@ create table events (
     txhash char(66) not null,
     blockhash char(66) not null,
     primary key (blockhash, index),
-    foreign key (txhash) references transactions(hash),
-    foreign key (blockhash) references blocks(hash)
+    foreign key (txhash) references transactions(hash) on delete cascade,
+    foreign key (blockhash) references blocks(hash) on delete cascade
 );
 
 create index on events(origin);
@@ -75,7 +75,7 @@ create table delivery_history (
     client char(42) not null,
     ts timestamp not null,
     endpoint varchar(100) not null,
-    datalength bigint not null,
+    datalength bigint not null
 );
 
 create index on delivery_history(client);


### PR DESCRIPTION
## Why ?

I noticed, sometimes when re-organisations happen, already put block entries need to be updated with latest one found from full node ( via RPC/ WS ), which involves first deleting all packed transactions/ events in that block ( along with self ) & then putting new block entry in database again. 

I decided to simplify the flow by introducing cascaded deletion, which requires only calling single function for deleting block entry ( identified using block number ), deletes all transactions/ events previously included in block. Finally call another function to create new block entry, then put transactions/ events. 