### PR TITLE
add implementation for EtteHttpServer option (flag to expose REST API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ cd ette
     ---
 
     - For testing historical data query using browser based GraphQL Playground in `ette`, you can set `EtteGraphQLPlayGround` to `yes` in config file
+    - For exposing `ette`'s REST API set `EtteHttpServer` to `yes`.
     - For processing block(s)/ tx(s) concurrently, it'll create `ConcurrencyFactor * #-of CPUs on machine` workers, who will pick up jobs submitted to them.
     - If nothing is specified, it defaults to 1 & assuming you're running `ette` on machine with 4 CPUs, it'll spawn worker pool of size 4. But more number of jobs can be submitted, only 4 can be running at max.
     - 👆 being done for controlling concurrency level, by putting more control on user's hand.
@@ -149,6 +150,7 @@ Domain=localhost
 Production=yes
 EtteMode=3
 EtteGraphQLPlayGround=yes
+EtteHttpServer=yes
 ConcurrencyFactor=5
 BlockConfirmations=200
 BlockRange=1000

--- a/app/app.go
+++ b/app/app.go
@@ -122,6 +122,10 @@ func Run(configFile, subscriptionPlansFile string) {
 	// go srv.DeliveryHistoryCleanUpService(_db)
 
 	// Starting http server on main thread
-	rest.RunHTTPServer(_db, _status, _redisClient)
+	if cfg.Get("EtteHttpServer") == "yes" {
+		rest.RunHTTPServer(_db, _status, _redisClient)
+	} else {
+		select {}
+	}
 
 }


### PR DESCRIPTION
I required for ette to work only as a service that populated the PostgreSQL database.

GraphQL can be disabled by `EtteGraphQLPlayGround` setting.
Live subscription can be disabled by using the appropriate `EtteMode` setting.
But, there was no way to disable the REST HTTP server.

This change adds an additional setting, `EtteHttpServer` in `.env` file.
If it is not `true`, then the HTTP server won't start.
In this case, to avoid the immediate termination of ette, the Run method is blocked.