### PR TITLE
feat: Create the client pool to rotate RPC clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ cd ette
     - If you're attempting to take snapshot/ restore from binary snapshot file, you can set `SnapshotFile` in `.env` file, to set sink/ source file name, respectively. Default file name `echo $(echo $(pwd)/snapshot.bin)` in i.e. from where `ette` gets invoked. Consider setting `EtteMode` correctly, depending upon what you want to attain.
 
 ```
-RPCUrl=https://<domain-name>
-WebsocketUrl=wss://<domain-name>
+RPCUrls=https://<domain-name>,https://<other-domain-name>
+WebsocketUrls=wss://<domain-name>,wss://<other-domain-name>
 PORT=7000
 DB_USER=user
 DB_PASSWORD=password

--- a/app/client.go
+++ b/app/client.go
@@ -2,32 +2,9 @@ package app
 
 import (
 	"context"
-	"log"
-
 	"github.com/go-redis/redis/v8"
-
-	"github.com/ethereum/go-ethereum/ethclient"
 	cfg "github.com/itzmeanjan/ette/app/config"
 )
-
-// Connect to blockchain node, either using HTTP or Websocket connection
-// depending upon true/ false, passed to function, respectively
-func getClient(isRPC bool) *ethclient.Client {
-	var client *ethclient.Client
-	var err error
-
-	if isRPC {
-		client, err = ethclient.Dial(cfg.Get("RPCUrl"))
-	} else {
-		client, err = ethclient.Dial(cfg.Get("WebsocketUrl"))
-	}
-
-	if err != nil {
-		log.Fatalf("[!] Failed to connect to blockchain : %s\n", err.Error())
-	}
-
-	return client
-}
 
 // Creates connection to Redis server & returns that handle to be used for further communication
 func getRedisClient() *redis.Client {

--- a/app/client/client.go
+++ b/app/client/client.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"log"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	cfg "github.com/itzmeanjan/ette/app/config"
+)
+
+type Client struct {
+	client            *ethclient.Client
+	rpcUrl            string
+	err               error
+	availableAt       time.Time
+	isWebsocketClient bool
+}
+
+func (c *Client) isAvailable() bool {
+	if c.err != nil || time.Now().Before(c.availableAt) {
+		return false
+	}
+	return true
+}
+
+func (c *Client) setError(err error, availableAt time.Time) {
+	c.err = err
+	c.availableAt = availableAt
+}
+
+func (c *Client) GetClient() *ethclient.Client {
+	if c.client == nil {
+		log.Fatal("❗️ No available client")
+	}
+	return c.client
+}
+
+// Connect to blockchain different nodes, either using HTTP or Websocket connection
+// depending upon true/ false, passed to function, respectively
+func getClients() (httpClients []*Client, webSocketClients []*Client) {
+	initClientFunc := func(isRPC bool) []*Client {
+		clients := make([]*Client, 0)
+		var urls []string
+		if isRPC {
+			urls = strings.Split(cfg.Get("RPCUrls"), ",")
+		} else {
+			urls = strings.Split(cfg.Get("WebsocketUrls"), ",")
+		}
+		isWebsocketClient := !isRPC
+		for _, rpcUrl := range urls {
+			// If the URL is empty, ignore the invalid eth client
+			if rpcUrl == "" {
+				continue
+			}
+			client, err := ethclient.Dial(rpcUrl)
+			if err != nil {
+				log.Fatalf("[!] Failed to connect to blockchain : %s\n", err.Error())
+			}
+			clients = append(clients, &Client{
+				client:            client,
+				err:               nil,
+				availableAt:       time.Now(),
+				rpcUrl:            rpcUrl,
+				isWebsocketClient: isWebsocketClient,
+			})
+		}
+		return clients
+	}
+	httpClients = initClientFunc(true)
+	webSocketClients = initClientFunc(false)
+	return httpClients, webSocketClients
+}

--- a/app/client/client.go
+++ b/app/client/client.go
@@ -18,10 +18,11 @@ type Client struct {
 }
 
 func (c *Client) isAvailable() bool {
-	if c.err != nil || time.Now().Before(c.availableAt) {
-		return false
+	if c.err == nil || time.Now().After(c.availableAt) {
+		c.err = nil
+		return true
 	}
-	return true
+	return false
 }
 
 func (c *Client) setError(err error, availableAt time.Time) {

--- a/app/client/client_pool.go
+++ b/app/client/client_pool.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// Pool Creates many HTTP clients and WebSocket clients to rotate RPC clients when
+// one of them has an error
+//
+// We set this client as unavailable
+type Pool struct {
+	httpClients      []*Client
+	webSocketClients []*Client
+	mu               sync.Mutex
+	retryTimes       int
+}
+
+// DefaultClientPool Create the default pool with specific options
+func DefaultClientPool() *Pool {
+	httpClients, webSocketClients := getClients()
+	clientPool := NewClientPool(
+		WithHttpClients(httpClients),
+		WithWebsocketClients(webSocketClients),
+		WithRetryTimes(5),
+	)
+	return clientPool
+}
+
+// NewClientPool Create pool with many options
+func NewClientPool(options ...func(*Pool)) *Pool {
+	pool := DefaultClientPool()
+
+	for _, o := range options {
+		o(pool)
+	}
+	return pool
+}
+
+// WithHttpClients create pool with http clients
+func WithHttpClients(httpClients []*Client) func(*Pool) {
+	return func(pool *Pool) {
+		pool.httpClients = httpClients
+	}
+}
+
+// WithWebsocketClients create pool with websocket clients
+func WithWebsocketClients(websocketClients []*Client) func(*Pool) {
+	return func(pool *Pool) {
+		pool.webSocketClients = websocketClients
+	}
+}
+
+// WithRetryTimes create pool with retry times to get the available client
+func WithRetryTimes(retryTimes int) func(*Pool) {
+	return func(pool *Pool) {
+		pool.retryTimes = retryTimes
+	}
+}
+
+// GetAvailableClient get the currently available client
+// If we try to get the available client many times, we return an error to check the RPC configuration
+// If the client is available, we use this to interact with the blockchain node
+func (p *Pool) GetAvailableClient(isRPC bool) (*Client, error) {
+	var clients []*Client
+	if isRPC {
+		clients = p.httpClients
+	} else {
+		clients = p.webSocketClients
+	}
+	// Lock the process to prevent concurrently picking some unavailable clients
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	retried := 0
+	for retried <= p.retryTimes {
+		for _, c := range clients {
+			if c.isAvailable() {
+				return c, nil
+			}
+		}
+		// If there is no client available at this time, sleep 1s to retry again
+		time.Sleep(1 * time.Second)
+		retried++
+	}
+	return nil, errors.New("[!] there are no clients available, please check the RPCs configuration")
+}

--- a/app/client/client_pool_test.go
+++ b/app/client/client_pool_test.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	cfg "github.com/itzmeanjan/ette/app/config"
+	"github.com/stretchr/testify/assert"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func readConfig() error {
+	configFile, err := filepath.Abs("../../.env")
+	if err != nil {
+		return errors.New(fmt.Sprintf("[!] Failed to find `.env` : %s\n", err.Error()))
+	}
+
+	err = cfg.Read(configFile)
+	if err != nil {
+		return errors.New(fmt.Sprintf("[!] Failed to read `.env` : %s\n", err.Error()))
+	}
+	return nil
+}
+
+func Test_NewClientPool(t *testing.T) {
+	// TODO: must read config before getting clients
+	err := readConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vitalikEth := "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+
+	clientPool := NewClientPool()
+	client, err := clientPool.GetAvailableClient(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	balanceAt, err := client.GetClient().BalanceAt(context.Background(), common.HexToAddress(vitalikEth), nil)
+	if err != nil {
+		client.setError(err, time.Now().Add(1*time.Minute))
+		t.Fatal(err)
+	}
+	t.Log(balanceAt.Int64())
+}
+
+func Test_SetError(t *testing.T) {
+	// TODO: must read config before getting clients
+	err := readConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientPool := NewClientPool()
+	client, err := clientPool.GetAvailableClient(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.setError(errors.New("reach limit exceed"), time.Now().Add(1*time.Minute))
+
+	otherClient, err := clientPool.GetAvailableClient(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotEqual(t, client.rpcUrl, otherClient.rpcUrl)
+}

--- a/app/data/data.go
+++ b/app/data/data.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"github.com/itzmeanjan/ette/app/client"
 	"sync"
 	"time"
 
@@ -162,6 +163,5 @@ type Job struct {
 // Use `RPC` i.e. HTTP based connection, for querying blockchain for data
 // Use `Websocket` for real-time listening of events in blockchain
 type BlockChainNodeConnection struct {
-	RPC       *ethclient.Client
-	Websocket *ethclient.Client
+	ClientPool *client.Pool
 }

--- a/app/setup.go
+++ b/app/setup.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"github.com/itzmeanjan/ette/app/client"
 	"log"
 	"sync"
 
@@ -29,8 +30,7 @@ func bootstrap(configFile, subscriptionPlansFile string) (*d.BlockChainNodeConne
 
 	// Maintaining both HTTP & Websocket based connection to blockchain
 	_connection := &d.BlockChainNodeConnection{
-		RPC:       getClient(true),
-		Websocket: getClient(false),
+		ClientPool: client.NewClientPool(),
 	}
 
 	_redisClient := getRedisClient()


### PR DESCRIPTION
Hi @itzmeanjan 
When I run `ette` on my local computer, I faced some problems with RPC clients when I reach the limit exceeded, or sometimes the blockchain nodes are unhealthy.
So I made PR to create the client pool with many ETH clients to rotate between it when any clients are wrong!

Please check my PR and respond to me!